### PR TITLE
#104

### DIFF
--- a/src/main/java/com/cflint/CFLint.java
+++ b/src/main/java/com/cflint/CFLint.java
@@ -21,14 +21,13 @@ import org.antlr.runtime.IntStream;
 import org.antlr.runtime.RecognitionException;
 import org.antlr.v4.runtime.Parser;
 import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.atn.ATNConfigSet;
 import org.antlr.v4.runtime.dfa.DFA;
 
 import cfml.CFSCRIPTLexer;
 import cfml.parsing.CFMLParser;
 import cfml.parsing.CFMLSource;
-import cfml.parsing.cfml.ErrorEvent;
-import cfml.parsing.cfml.IErrorObserver;
 import cfml.parsing.cfscript.CFAssignmentExpression;
 import cfml.parsing.cfscript.CFBinaryExpression;
 import cfml.parsing.cfscript.CFExpression;
@@ -775,7 +774,13 @@ public class CFLint implements IErrorReporter {
 			Object offendingSymbol, int line, int charPositionInLine,
 			String msg, org.antlr.v4.runtime.RecognitionException e) {
 		final String file = currentFile == null ? "" : currentFile + "\r\n";
-		//System.err.println(file + "----syntax error ---" + line + " : " + charPositionInLine);
+		String expression=null;
+		if(offendingSymbol instanceof Token){
+			expression = ((Token) offendingSymbol).getText();
+			if(expression.length() > 50){
+				expression=expression.substring(1,40) + "...";
+			}
+		}
 		if(!currentElement.isEmpty()){
 			Element elem = currentElement.peek();
 			if(line == 1){
@@ -785,7 +790,17 @@ public class CFLint implements IErrorReporter {
 				line = elem.getSource().getRow(elem.getBegin()) + line - 1;
 			}
 		}
-		fireCFLintException(e,PARSE_ERROR,currentFile,line,charPositionInLine,"",offendingSymbol==null?"":offendingSymbol.toString());
+		if(recognizer instanceof Parser && ((Parser)recognizer).getExpectedTokens().contains(65)){
+			bugs.add(new BugInfo.BugInfoBuilder().setMessageCode("PARSE_ERROR")
+			.setFilename(file).setMessage("End of statement(;) expected instead of " + expression).setSeverity("ERROR")
+			.setExpression(expression)
+			.setLine(line).setColumn(charPositionInLine)
+			.build());
+
+		}else{
+			
+			fireCFLintException(e,PARSE_ERROR,file,line,charPositionInLine,"",msg);
+		}
 	}
 	public void reportAmbiguity(Parser recognizer, DFA dfa, int startIndex,
 			int stopIndex, boolean exact, java.util.BitSet ambigAlts,


### PR DESCRIPTION
@atuttle
Here's my attempt to make the missing semi-colon case cleaner.  If semi-colon is one of the suggested missing tokens, that parse error has a message specifically about end of statement missing.