### PR TITLE
Merging collapsible if statements increases the code's readability

### DIFF
--- a/src/main/java/com/cflint/JSONOutput.java
+++ b/src/main/java/com/cflint/JSONOutput.java
@@ -111,10 +111,9 @@ public class JSONOutput {
 		}
 		// Some message codes (such as parse error are grouped at the function
 		// level
-		if (CODE_GROUPBY_FUNCTION.contains(bugInfo.getMessageCode())) {
-			if (safeEquals(prevbugInfo.getFunction(), bugInfo.getFunction())) {
+		if (CODE_GROUPBY_FUNCTION.contains(bugInfo.getMessageCode())
+			&& safeEquals(prevbugInfo.getFunction(), bugInfo.getFunction())) {
 				return true;
-			}
 		}
 		return false;
 	}

--- a/src/main/java/com/cflint/XMLOutput.java
+++ b/src/main/java/com/cflint/XMLOutput.java
@@ -100,10 +100,9 @@ public class XMLOutput {
 		}
 		// Some message codes (such as parse error are grouped at the function
 		// level
-		if (CODE_GROUPBY_FUNCTION.contains(bugInfo.getMessageCode())) {
-			if (safeEquals(prevbugInfo.getFunction(), bugInfo.getFunction())) {
+		if (CODE_GROUPBY_FUNCTION.contains(bugInfo.getMessageCode())
+			&& safeEquals(prevbugInfo.getFunction(), bugInfo.getFunction())) {
 				return true;
-			}
 		}
 		return false;
 	}

--- a/src/main/java/com/cflint/main/CFLintMain.java
+++ b/src/main/java/com/cflint/main/CFLintMain.java
@@ -368,10 +368,8 @@ public class CFLintMain {
 			}
 		}
 		if (textOutput) {
-			if(textOutFile != null){
-				if(verbose) {
-					display("Writing text" + (stdOut ? "." : " to " + textOutFile));
-				}
+			if(textOutFile != null && verbose){
+				display("Writing text" + (stdOut ? "." : " to " + textOutFile));
 			}
 			Writer textwriter = stdOut || textOutFile==null ? new OutputStreamWriter(System.out) : new FileWriter(textOutFile);
 			new TextOutput().output(cflint.getBugs(), textwriter, showStats);

--- a/src/main/java/com/cflint/plugins/core/TooManyFunctionsChecker.java
+++ b/src/main/java/com/cflint/plugins/core/TooManyFunctionsChecker.java
@@ -43,13 +43,11 @@ public class TooManyFunctionsChecker extends CFLintScannerAdapter {
 			functionCount = 0;
 			alreadyTooMany = false;
 		}
-		else if (element.getName().equals("cffunction")) {
-			if (!trivalFunction(context.getFunctionName())) {
-				functionCount++;
+		else if (element.getName().equals("cffunction") && !trivalFunction(context.getFunctionName())) {
+			functionCount++;
 
-				if (!alreadyTooMany) {
-					checkNumberFunctions(functionCount, 1, context, bugs);
-				}
+			if (!alreadyTooMany) {
+				checkNumberFunctions(functionCount, 1, context, bugs);
 			}
 		}
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1066 - “Collapsible "if" statements should be merged”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1066
Please let me know if you have any questions.
Ayman Abdelghany.