### PR TITLE
Reset checker's statistics before analyzing each file.

### DIFF
--- a/src/main/java/com/cflint/plugins/core/SimpleComplexityChecker.java
+++ b/src/main/java/com/cflint/plugins/core/SimpleComplexityChecker.java
@@ -25,6 +25,13 @@ public class SimpleComplexityChecker extends CFLintScannerAdapter {
 	int functionLineNo = 1;
 
 	@Override
+	public void startFile(String fileName, BugList bugs) {
+		complexity = 0;
+		alreadyTooComplex = false;
+		functionLineNo = 1;
+	}
+
+	@Override
 	public void expression(final CFScriptStatement expression, final Context context, final BugList bugs) {
 		CFFuncDeclStatement function;
 


### PR DESCRIPTION
For some files calculated complexity isn't properly ended. This causes errors in complexity outcome.