### PR TITLE
Workaround context leaking

### DIFF
--- a/src/main/java/com/cflint/CFLint.java
+++ b/src/main/java/com/cflint/CFLint.java
@@ -77,7 +77,7 @@ public class CFLint implements IErrorReporter {
 	private static final String FILE_ERROR = "FILE_ERROR";
 	private static final String PARSE_ERROR = "PARSE_ERROR";
 	public static final String PLUGIN_ERROR = "PLUGIN_ERROR:";
-	final CFMLParser cfmlParser = new CFMLParser();
+	CFMLParser cfmlParser = new CFMLParser();
 	
 	
 	StackHandler handler = new StackHandler();
@@ -298,7 +298,7 @@ public class CFLint implements IErrorReporter {
 		}
 	}
 
-	
+
 	private void process(final Element elem, final String space, Context context)
 			throws ParseException, IOException {
 		context.setInComponent(inComponent);
@@ -946,6 +946,8 @@ public class CFLint implements IErrorReporter {
 	}
 
 	protected void fireStartedProcessing(final String srcidentifier) {
+		cfmlParser = new CFMLParser();
+		cfmlParser.setErrorReporter(this);
 		currentFile = srcidentifier;
 		for (final CFLintStructureListener structurePlugin : getStructureListeners(extensions)) {
 			try{


### PR DESCRIPTION
In some situations CFMLParser mixes content of analyzed files. That's why we need to create separate instance of CFMLParser for each file.