### PR TITLE
Fixed wrong parameter in error message

### DIFF
--- a/src/main/java/com/cflint/main/CFLintMain.java
+++ b/src/main/java/com/cflint/main/CFLintMain.java
@@ -456,7 +456,7 @@ public class CFLintMain {
 
 	private boolean isValid() {
 		if (folder.isEmpty() && !stdIn) {
-			System.err.println("Set -scanFolder or -stdin");
+			System.err.println("Set -folder or -stdin");
 			return false;
 		}
 		return true;


### PR DESCRIPTION
scanFolder doesn't exist anymore as a parameter - fixed error message.