### PR TITLE
Update SureFire argLine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
 			    <configuration>
 			        <forkCount>1</forkCount>
 			        <reuseForks>true</reuseForks>
-			        <argLine>-Xmx2048m</argLine>
+			        <argLine>-Xmx2g</argLine>
 			    </configuration>
 			  </plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,7 @@
 			    <configuration>
 			        <forkCount>1</forkCount>
 			        <reuseForks>true</reuseForks>
-			        <argLine>-Xmx2048m -XX:MaxPermSize=256m</argLine>
+			        <argLine>-Xmx2048m</argLine>
 			    </configuration>
 			  </plugin>
 		</plugins>


### PR DESCRIPTION
Updating the `argLine` parameter of the SureFire plugin, removing `MaxPermSize`, which was removed altogether in Java 8, and updating the size format for max heap size for readability.