### PR TITLE
299 refactoring stats

### DIFF
--- a/src/main/java/com/cflint/CFLintStats.java
+++ b/src/main/java/com/cflint/CFLintStats.java
@@ -10,6 +10,8 @@ public class CFLintStats {
 	private long fileCount;
 	// Number of lines
 	private BigInteger totalSize = BigInteger.ZERO;
+	// Bug counts for current execution
+	private BugCounts counts = new BugCounts();
 
 	public CFLintStats() {
 		super();
@@ -34,4 +36,6 @@ public class CFLintStats {
 	public BigInteger getTotalSize() {
 		return totalSize;
 	}
+
+	public BugCounts getCounts() { return counts; }
 }

--- a/src/main/java/com/cflint/CFLintStats.java
+++ b/src/main/java/com/cflint/CFLintStats.java
@@ -23,6 +23,14 @@ public class CFLintStats {
 		this.fileCount = fileCount;
 		this.totalSize = totalSize;
 	}
+
+	public CFLintStats(long timestamp, long fileCount, BigInteger totalSize, BugCounts counts) {
+		super();
+		this.timestamp = timestamp;
+		this.fileCount = fileCount;
+		this.totalSize = totalSize;
+		this.counts = counts;
+	}
 	
 	public void addFile(long numberOfLines){
 		fileCount++;

--- a/src/main/java/com/cflint/JSONOutput.java
+++ b/src/main/java/com/cflint/JSONOutput.java
@@ -46,7 +46,6 @@ public class JSONOutput {
             while (bugInfo != null) {
                 final String severity = currentList.get(0).getSeverity();
                 final String code = currentList.get(0).getMessageCode();
-                counts.add(code, severity);
 
                 jg.writeStartObject();
                 jg.writeStringField("severity", notNull(severity));

--- a/src/main/java/com/cflint/JSONOutput.java
+++ b/src/main/java/com/cflint/JSONOutput.java
@@ -26,8 +26,8 @@ public class JSONOutput {
         this.prettyPrint = prettyPrint;
     }
 
-    public void output(final BugList bugList, final Writer writer, final boolean showStats) throws IOException {
-        final BugCounts counts = new BugCounts();
+    public void output(final BugList bugList, final Writer writer, final boolean showStats, CFLintStats stats) throws IOException {
+        final BugCounts counts = stats.getCounts();
         // final StringBuilder sb = new StringBuilder();
         final JsonFactory jsonF = new JsonFactory();
         final JsonGenerator jg = jsonF.createGenerator(writer);
@@ -122,12 +122,6 @@ public class JSONOutput {
 
     private boolean safeEquals(final String a, final String b) {
         return a != null && b != null && a.equals(b);
-    }
-
-    public void outputFindBugs(final BugList bugList, final Writer writer, final boolean showStats)
-            throws IOException, TransformerException {
-        final StringWriter sw = new StringWriter();
-        output(bugList, sw, showStats);
     }
 
     private String filename(final String filename) {

--- a/src/main/java/com/cflint/TextOutput.java
+++ b/src/main/java/com/cflint/TextOutput.java
@@ -10,8 +10,8 @@ public class TextOutput {
 
     final static String newLine = System.getProperty("line.separator");
 
-    public void output(final BugList bugList, final Writer sb, final boolean showStats) throws IOException {
-        final BugCounts counts = new BugCounts();
+    public void output(final BugList bugList, final Writer sb, final boolean showStats, CFLintStats stats) throws IOException {
+        final BugCounts counts = stats.getCounts();
 
         for (final Entry<String, List<BugInfo>> bugEntry : bugList.getBugList().entrySet()) {
             sb.append("Issue");

--- a/src/main/java/com/cflint/TextOutput.java
+++ b/src/main/java/com/cflint/TextOutput.java
@@ -18,7 +18,6 @@ public class TextOutput {
             for (final BugInfo bugInfo : bugEntry.getValue()) {
                 final String severity = bugEntry.getValue().get(0).getSeverity();
                 final String code = bugEntry.getValue().get(0).getMessageCode();
-                counts.add(code, severity);
                 sb.append(newLine).append("Severity:").append(severity);
                 sb.append(newLine).append("Message code:").append(code);
                 sb.append(newLine).append("\tFile:").append(bugInfo.getFilename());

--- a/src/main/java/com/cflint/XMLOutput.java
+++ b/src/main/java/com/cflint/XMLOutput.java
@@ -31,7 +31,6 @@ public class XMLOutput {
             while (bugInfo != null) {
                 final String severity = bugEntry.getValue().get(0).getSeverity();
                 final String code = bugEntry.getValue().get(0).getMessageCode();
-                counts.add(code, severity);
                 writer.append("<issue");
                 writer.append(" severity=\"").append(xmlEscapeText(severity)).append("\"");
                 writer.append(" id=\"").append(xmlEscapeText(code)).append("\"");

--- a/src/main/java/com/cflint/XMLOutput.java
+++ b/src/main/java/com/cflint/XMLOutput.java
@@ -19,7 +19,7 @@ public class XMLOutput {
     public static final String LINE_SEPARATOR = "line.separator";
 
     public void output(final BugList bugList, final Writer writer, final boolean showStats, final CFLintStats stats) throws IOException {
-        final BugCounts counts = new BugCounts();
+        final BugCounts counts = stats.getCounts();
         writer.append("<issues version=\"" + Version.getVersion() + "\"")
                 .append(" timestamp=\"" + Long.toString(stats.getTimestamp()) + "\">")
                 .append(System.getProperty(LINE_SEPARATOR));

--- a/src/main/java/com/cflint/ant/CFLintTask.java
+++ b/src/main/java/com/cflint/ant/CFLintTask.java
@@ -107,13 +107,13 @@ public class CFLintTask extends Task {
                             showStats, cflint.getStats());
                 } else {
                     new DefaultCFlintResultMarshaller().output(cflint.getBugs(),
-                            createWriter(xmlFile, StandardCharsets.UTF_8), showStats);
+                            createWriter(xmlFile, StandardCharsets.UTF_8), showStats,cflint.getStats());
                 }
             }
             if (textFile != null) {
                 final Writer textwriter = textFile != null ? new FileWriter(textFile)
                         : new OutputStreamWriter(System.out);
-                new TextOutput().output(cflint.getBugs(), textwriter, showStats);
+                new TextOutput().output(cflint.getBugs(), textwriter, showStats,cflint.getStats());
 
             }
             if (htmlFile != null) {

--- a/src/main/java/com/cflint/main/CFLintMain.java
+++ b/src/main/java/com/cflint/main/CFLintMain.java
@@ -25,18 +25,13 @@ import javax.swing.JOptionPane;
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.TransformerException;
 
+import com.cflint.*;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.CommandLineParser;
 import org.apache.commons.cli.GnuParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 
-import com.cflint.CFLint;
-import com.cflint.HTMLOutput;
-import com.cflint.JSONOutput;
-import com.cflint.TextOutput;
-import com.cflint.Version;
-import com.cflint.XMLOutput;
 import com.cflint.config.CFLintChainedConfig;
 import com.cflint.config.CFLintConfig;
 import com.cflint.config.CFLintConfiguration;
@@ -453,6 +448,9 @@ public class CFLintMain {
             }
             scanner.close();
             cflint.process(source.toString(), stdInFile);
+        }
+        for (BugInfo bug : cflint.getBugs()) {
+            cflint.getStats().getCounts().add(bug.getMessageCode(), bug.getSeverity());
         }
         if (xmlOutput) {
             final Writer xmlwriter = stdOut ? new OutputStreamWriter(System.out)

--- a/src/main/java/com/cflint/main/CFLintMain.java
+++ b/src/main/java/com/cflint/main/CFLintMain.java
@@ -466,7 +466,7 @@ public class CFLintMain {
                 if (verbose) {
                     display("Writing XML" + (stdOut ? "." : " to " + xmlOutFile));
                 }
-                new DefaultCFlintResultMarshaller().output(cflint.getBugs(), xmlwriter, showStats);
+                new DefaultCFlintResultMarshaller().output(cflint.getBugs(), xmlwriter, showStats, cflint.getStats());
             }
         }
         if (textOutput) {
@@ -475,7 +475,7 @@ public class CFLintMain {
             }
             final Writer textwriter = stdOut || textOutFile == null ? new OutputStreamWriter(System.out)
                     : new FileWriter(textOutFile);
-            new TextOutput().output(cflint.getBugs(), textwriter, showStats);
+            new TextOutput().output(cflint.getBugs(), textwriter, showStats,cflint.getStats());
         }
         if (htmlOutput) {
             try {
@@ -493,7 +493,7 @@ public class CFLintMain {
                 display("Writing JSON" + (stdOut ? "." : " to " + jsonOutFile));
             }
             final Writer jsonwriter = stdOut ? new OutputStreamWriter(System.out) : new FileWriter(jsonOutFile);
-            new JSONOutput().output(cflint.getBugs(), jsonwriter, showStats);
+            new JSONOutput().output(cflint.getBugs(), jsonwriter, showStats, cflint.getStats());
         }
         if (verbose) {
             display("Total files scanned: " + cflint.getStats().getFileCount());

--- a/src/main/java/com/cflint/xml/CFLintResultMarshaller.java
+++ b/src/main/java/com/cflint/xml/CFLintResultMarshaller.java
@@ -3,9 +3,10 @@ package com.cflint.xml;
 import java.io.Writer;
 
 import com.cflint.BugList;
+import com.cflint.CFLintStats;
 
 public interface CFLintResultMarshaller {
 
-    void output(BugList bugList, Writer writer, boolean showStats) throws MarshallerException;
+    void output(BugList bugList, Writer writer, boolean showStats, CFLintStats stats) throws MarshallerException;
 
 }

--- a/src/main/java/com/cflint/xml/stax/DefaultCFlintResultMarshaller.java
+++ b/src/main/java/com/cflint/xml/stax/DefaultCFlintResultMarshaller.java
@@ -7,10 +7,7 @@ import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
-import com.cflint.BugCounts;
-import com.cflint.BugInfo;
-import com.cflint.BugList;
-import com.cflint.Version;
+import com.cflint.*;
 import com.cflint.xml.CFLintResultMarshaller;
 import com.cflint.xml.MarshallerException;
 
@@ -22,13 +19,13 @@ import javanet.staxutils.IndentingXMLStreamWriter;
 public class DefaultCFlintResultMarshaller implements CFLintResultMarshaller {
 
     @Override
-    public void output(BugList bugList, Writer writer, boolean showStats) throws MarshallerException {
+    public void output(BugList bugList, Writer writer, boolean showStats, CFLintStats stats) throws MarshallerException {
 
         try {
             final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newInstance();
             XMLStreamWriter xtw = new IndentingXMLStreamWriter(xmlOutputFactory.createXMLStreamWriter(writer));
 
-            writeIssues(bugList, xtw, showStats);
+            writeIssues(bugList, xtw, showStats, stats);
 
             xtw.flush();
 
@@ -37,11 +34,11 @@ public class DefaultCFlintResultMarshaller implements CFLintResultMarshaller {
         }
     }
 
-    private void writeIssues(BugList bugList, XMLStreamWriter xtw, boolean showStats) throws XMLStreamException {
+    private void writeIssues(BugList bugList, XMLStreamWriter xtw, boolean showStats, CFLintStats stats) throws XMLStreamException {
         xtw.writeStartElement("issues");
         xtw.writeAttribute("version", Version.getVersion());
 
-        BugCounts counts = new BugCounts();
+        BugCounts counts = stats.getCounts();
 
         for (BugInfo bug : bugList) {
 

--- a/src/main/java/com/cflint/xml/stax/DefaultCFlintResultMarshaller.java
+++ b/src/main/java/com/cflint/xml/stax/DefaultCFlintResultMarshaller.java
@@ -41,9 +41,6 @@ public class DefaultCFlintResultMarshaller implements CFLintResultMarshaller {
         BugCounts counts = stats.getCounts();
 
         for (BugInfo bug : bugList) {
-
-            counts.add(bug.getMessageCode(), bug.getSeverity());
-
             writeIssue(xtw, bug);
         }
 

--- a/src/main/java/com/cflint/xml/stax/FindBugsCFLintResultMarshaller.java
+++ b/src/main/java/com/cflint/xml/stax/FindBugsCFLintResultMarshaller.java
@@ -11,17 +11,18 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
 import com.cflint.BugList;
+import com.cflint.CFLintStats;
 import com.cflint.xml.CFLintResultMarshaller;
 import com.cflint.xml.MarshallerException;
 
 public class FindBugsCFLintResultMarshaller implements CFLintResultMarshaller {
 
     @Override
-    public void output(BugList bugList, Writer writer, boolean showStats) throws MarshallerException {
+    public void output(BugList bugList, Writer writer, boolean showStats, CFLintStats stats) throws MarshallerException {
         try {
             StringWriter sw = new StringWriter();
             DefaultCFlintResultMarshaller marshaller = new DefaultCFlintResultMarshaller();
-            marshaller.output(bugList, sw, showStats);
+            marshaller.output(bugList, sw, showStats, stats);
             sw.flush();
 
             final Transformer transformer = TransformerFactory.newInstance().newTransformer(

--- a/src/test/java/com/cflint/TestJSONOutput.java
+++ b/src/test/java/com/cflint/TestJSONOutput.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.math.BigInteger;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -27,7 +28,8 @@ public class TestJSONOutput {
 	public void testOutput() throws IOException {
 		BugInfo bugInfo = new BugInfo.BugInfoBuilder().setFunction("testf").setMessageCode("PARSE_ERROR").setFilename("c:\\temp\\test.cfc").build();
 		bugList.add(bugInfo);
-		outputer.output(bugList, writer, false);
+		CFLintStats stats = new CFLintStats(123456L,1,new BigInteger("545454"));
+		outputer.output(bugList, writer, false, stats);
 		String expectedText = "[{\"severity\":\"\",\"id\":\"PARSE_ERROR\",\"message\":\"PARSE_ERROR\",\"category\":\"CFLINT\",\"abbrev\":\"PE\",\"locations\":[{\"file\":\"c:\\\\temp\\\\test.cfc\",\"fileName\":\"test.cfc\",\"function\":\"testf\",\"column\":\"1\",\"line\":\"1\",\"message\":\"\",\"variable\":\"\",\"expression\":\"\"}]}]";
 //		assertEquals(JSONValue.parse(expectedText),JSONValue.parse(writer.toString()));
 		assertEquals(expectedText,writer.toString());
@@ -37,7 +39,8 @@ public class TestJSONOutput {
 	public void testStats() throws IOException {
 		BugInfo bugInfo = new BugInfo.BugInfoBuilder().setFunction("testf").setMessageCode("PARSE_ERROR").setFilename("c:\\temp\\test.cfc").build();
 		bugList.add(bugInfo);
-		outputer.output(bugList, writer, true);
+		CFLintStats stats = new CFLintStats(123456L,1,new BigInteger("545454"));
+		outputer.output(bugList, writer, true, stats);
 		String expectedText = "[{\"severity\":\"\",\"id\":\"PARSE_ERROR\",\"message\":\"PARSE_ERROR\",\"category\":\"CFLINT\",\"abbrev\":\"PE\",\"locations\":[{\"file\":\"c:\\\\temp\\\\test.cfc\",\"fileName\":\"test.cfc\",\"function\":\"testf\",\"column\":\"1\",\"line\":\"1\",\"message\":\"\",\"variable\":\"\",\"expression\":\"\"}]},{\"code\":\"PARSE_ERROR\",\"count\":\"1\"}]";
 		assertEquals(expectedText,writer.toString());
 	}

--- a/src/test/java/com/cflint/TestJSONOutput.java
+++ b/src/test/java/com/cflint/TestJSONOutput.java
@@ -39,9 +39,23 @@ public class TestJSONOutput {
 	public void testStats() throws IOException {
 		BugInfo bugInfo = new BugInfo.BugInfoBuilder().setFunction("testf").setMessageCode("PARSE_ERROR").setFilename("c:\\temp\\test.cfc").build();
 		bugList.add(bugInfo);
-		CFLintStats stats = new CFLintStats(123456L,1,new BigInteger("545454"));
+		BugCounts counts = new BugCounts();
+		counts.add("PARSE_ERROR", null);
+		CFLintStats stats = new CFLintStats(123456L,1,new BigInteger("545454"),counts);
 		outputer.output(bugList, writer, true, stats);
 		String expectedText = "[{\"severity\":\"\",\"id\":\"PARSE_ERROR\",\"message\":\"PARSE_ERROR\",\"category\":\"CFLINT\",\"abbrev\":\"PE\",\"locations\":[{\"file\":\"c:\\\\temp\\\\test.cfc\",\"fileName\":\"test.cfc\",\"function\":\"testf\",\"column\":\"1\",\"line\":\"1\",\"message\":\"\",\"variable\":\"\",\"expression\":\"\"}]},{\"code\":\"PARSE_ERROR\",\"count\":\"1\"}]";
+		assertEquals(expectedText,writer.toString());
+	}
+
+	@Test
+	public void testStatsWithSeverity() throws IOException {
+		BugInfo bugInfo = new BugInfo.BugInfoBuilder().setFunction("testf").setMessageCode("PARSE_ERROR").setSeverity("ERROR").setFilename("c:\\temp\\test.cfc").build();
+		bugList.add(bugInfo);
+		BugCounts counts = new BugCounts();
+		counts.add("PARSE_ERROR", "ERROR");
+		CFLintStats stats = new CFLintStats(123456L,1,new BigInteger("545454"),counts);
+		outputer.output(bugList, writer, true, stats);
+		String expectedText = "[{\"severity\":\"ERROR\",\"id\":\"PARSE_ERROR\",\"message\":\"PARSE_ERROR\",\"category\":\"CFLINT\",\"abbrev\":\"PE\",\"locations\":[{\"file\":\"c:\\\\temp\\\\test.cfc\",\"fileName\":\"test.cfc\",\"function\":\"testf\",\"column\":\"1\",\"line\":\"1\",\"message\":\"\",\"variable\":\"\",\"expression\":\"\"}]},{\"code\":\"PARSE_ERROR\",\"count\":\"1\"},{\"severity\":\"ERROR\",\"count\":\"1\"}]";
 		assertEquals(expectedText,writer.toString());
 	}
 	

--- a/src/test/java/com/cflint/TestXMLOutput.java
+++ b/src/test/java/com/cflint/TestXMLOutput.java
@@ -30,9 +30,9 @@ public class TestXMLOutput {
 		CFLintStats stats = new CFLintStats(123456L,1,new BigInteger("545454"));
 		outputer.output(bugList, writer, false, stats);
 		String expectedText = "<issues version=\"" + Version.getVersion() + "\" timestamp=\"123456\">\n" +
-"<issue severity=\"\" id=\"PARSE_ERROR\" message=\"PARSE_ERROR\" category=\"CFLint\" abbrev=\"PE\"><location file=\"c:\\temp\\test.cfc\" fileName=\"test.cfc\" function=\"testf\" column=\"1\" line=\"1\" message=\"\" variable=\"\"><Expression><![CDATA[]]></Expression></location>\n" +
-"</issue>\n" +
-"</issues>";
+			"<issue severity=\"\" id=\"PARSE_ERROR\" message=\"PARSE_ERROR\" category=\"CFLint\" abbrev=\"PE\"><location file=\"c:\\temp\\test.cfc\" fileName=\"test.cfc\" function=\"testf\" column=\"1\" line=\"1\" message=\"\" variable=\"\"><Expression><![CDATA[]]></Expression></location>\n" +
+			"</issue>\n" +
+			"</issues>";
 		//remove the version 
 		assertEquals(expectedText.replace("\n", "").replace("\r", ""),writer.toString().replace("\n", "").replace("\r", ""));
 	}
@@ -41,16 +41,38 @@ public class TestXMLOutput {
 	public void testStats() throws IOException {
 		BugInfo bugInfo = new BugInfo.BugInfoBuilder().setFunction("testf").setMessageCode("PARSE_ERROR").setFilename("c:\\temp\\test.cfc").build();
 		bugList.add(bugInfo);
-		CFLintStats stats = new CFLintStats(123456L,1,new BigInteger("545454"));
+		BugCounts counts = new BugCounts();
+		counts.add("PARSE_ERROR", null);
+		CFLintStats stats = new CFLintStats(123456L,1,new BigInteger("545454"), counts);
 		outputer.output(bugList, writer, true, stats);
 
 		String expectedText = "<issues version=\"" + Version.getVersion() + "\" timestamp=\"123456\">\n" +
-"<issue severity=\"\" id=\"PARSE_ERROR\" message=\"PARSE_ERROR\" category=\"CFLint\" abbrev=\"PE\"><location file=\"c:\\temp\\test.cfc\" fileName=\"test.cfc\" function=\"testf\" column=\"1\" line=\"1\" message=\"\" variable=\"\"><Expression><![CDATA[]]></Expression></location>\n" +
-"</issue>\n" +
-"<counts totalfiles=\"1\" totalsize=\"545454\">\n" +
-"<count code=\"PARSE_ERROR\" count=\"1\" />\n" +
-"</counts>" +
-"</issues>";
+			"<issue severity=\"\" id=\"PARSE_ERROR\" message=\"PARSE_ERROR\" category=\"CFLint\" abbrev=\"PE\"><location file=\"c:\\temp\\test.cfc\" fileName=\"test.cfc\" function=\"testf\" column=\"1\" line=\"1\" message=\"\" variable=\"\"><Expression><![CDATA[]]></Expression></location>\n" +
+			"</issue>\n" +
+			"<counts totalfiles=\"1\" totalsize=\"545454\">\n" +
+			"<count code=\"PARSE_ERROR\" count=\"1\" />\n" +
+			"</counts>" +
+			"</issues>";
+		assertEquals(expectedText.replace("\n", "").replace("\r", ""),writer.toString().replace("\n", "").replace("\r", ""));
+	}
+
+	@Test
+	public void testStatsAndSeverity() throws IOException {
+		BugInfo bugInfo = new BugInfo.BugInfoBuilder().setFunction("testf").setMessageCode("PARSE_ERROR").setSeverity("ERROR").setFilename("c:\\temp\\test.cfc").build();
+		bugList.add(bugInfo);
+		BugCounts counts = new BugCounts();
+		counts.add("PARSE_ERROR", "ERROR");
+		CFLintStats stats = new CFLintStats(123456L,1,new BigInteger("545454"), counts);
+		outputer.output(bugList, writer, true, stats);
+
+		String expectedText = "<issues version=\"" + Version.getVersion() + "\" timestamp=\"123456\">\n" +
+			"<issue severity=\"ERROR\" id=\"PARSE_ERROR\" message=\"PARSE_ERROR\" category=\"CFLint\" abbrev=\"PE\"><location file=\"c:\\temp\\test.cfc\" fileName=\"test.cfc\" function=\"testf\" column=\"1\" line=\"1\" message=\"\" variable=\"\"><Expression><![CDATA[]]></Expression></location>\n" +
+			"</issue>\n" +
+			"<counts totalfiles=\"1\" totalsize=\"545454\">\n" +
+			"<count code=\"PARSE_ERROR\" count=\"1\" />\n" +
+			"<count severity=\"ERROR\" count=\"1\" />" +
+			"</counts>" +
+			"</issues>";
 		assertEquals(expectedText.replace("\n", "").replace("\r", ""),writer.toString().replace("\n", "").replace("\r", ""));
 	}
 	

--- a/src/test/java/com/cflint/integration/TestFiles.java
+++ b/src/test/java/com/cflint/integration/TestFiles.java
@@ -96,7 +96,7 @@ public class TestFiles {
 		}
 		//List<BugInfo> result = cflint.getBugs().getFlatBugList();
 		StringWriter writer = new StringWriter();
-		new JSONOutput().output(cflint.getBugs(), writer, false);
+		new JSONOutput().output(cflint.getBugs(), writer, false,cflint.getStats());
 		
 		String actualTree=writer.toString();
 		if (expectedText == null || expectedText.trim().length() == 0) {


### PR DESCRIPTION
Please review - the idea is that Bug Count now happens once before any output is generated and not (potentially) multiple times for each output format. That "global" bug count then becomes a part of CFLintStats and gets passed into each output routine.