### PR TITLE
POM dependency cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<maven.compiler.source>1.7</maven.compiler.source>
 		<maven.compiler.target>1.7</maven.compiler.target>
 
-		<cfparser.version>2.4.6</cfparser.version>
+		<cfparser.version>2.4.8</cfparser.version>
 		<jackson.version>2.8.6</jackson.version>
 		<slf4j.version>1.7.21</slf4j.version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
-			<scope>compile</scope>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jdom</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
 			<version>0.6</version>
 		</dependency>
 		<dependency>
-			<groupId>ant</groupId>
+			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
 			<version>1.7.0</version>
 			<scope>compile</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,6 @@
 			<groupId>net.htmlparser.jericho</groupId>
 			<artifactId>jericho-html</artifactId>
 			<version>3.4</version>
-			<!-- scope>runtime</scope-->
 		</dependency>
 		<dependency>
 			<groupId>javolution</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,13 +100,11 @@
 			<groupId>org.antlr</groupId>
 			<artifactId>stringtemplate</artifactId>
 			<version>4.0.2</version>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr4</artifactId>
 			<version>4.6</version>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
@@ -130,7 +128,6 @@
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.2</version>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>ro.fortsoft.pf4j</groupId>
@@ -141,7 +138,6 @@
 			<groupId>org.apache.ant</groupId>
 			<artifactId>ant</artifactId>
 			<version>1.7.0</version>
-			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.sun.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -98,9 +98,8 @@
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging-api</artifactId>
-			<version>1.1</version>
-			<scope>runtime</scope>
+			<artifactId>commons-logging</artifactId>
+			<version>1.2</version>
 		</dependency>
 		<dependency>
 			<groupId>net.htmlparser.jericho</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,8 @@
 		<maven.compiler.target>1.7</maven.compiler.target>
 
 		<cfparser.version>2.4.6</cfparser.version>
+		<jackson.version>2.8.6</jackson.version>
+		<slf4j.version>1.7.21</slf4j.version>
 	</properties>
   
 	<dependencies>
@@ -149,27 +151,27 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.8.6</version>
+			<version>${jackson.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.8.6</version>
+			<version>${jackson.version}</version>
 		</dependency>
 		<dependency>
 		  <groupId>com.fasterxml.jackson.module</groupId>
 		  <artifactId>jackson-module-jaxb-annotations</artifactId>
-		  <version>2.8.6</version>
+		  <version>${jackson.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-api</artifactId>
-		    <version>1.7.21</version>
+		    <version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.slf4j</groupId>
 		    <artifactId>slf4j-simple</artifactId>
-		    <version>1.7.21</version>
+		    <version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.java.dev.stax-utils</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,6 @@
 			<version>${cfparser.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.jdom</groupId>
 			<artifactId>jdom</artifactId>
 			<version>1.1.3</version>
@@ -194,7 +188,14 @@
 		    <artifactId>commons-io</artifactId>
 		    <version>2.5</version>
 		</dependency>
-		
+
+		<!-- Test Dependencies -->
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.12</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -84,14 +84,12 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
-			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.jdom</groupId>
 			<artifactId>jdom</artifactId>
 			<version>1.1.3</version>
-			<type>jar</type>
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
@@ -108,14 +106,12 @@
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr4</artifactId>
 			<version>4.6</version>
-			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>
 			<artifactId>commons-logging-api</artifactId>
 			<version>1.1</version>
-			<type>jar</type>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -128,14 +124,12 @@
 			<groupId>org.javolution</groupId>
 			<artifactId>javolution</artifactId>
 			<version>5.2.6</version>
-			<type>jar</type>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>
 			<artifactId>commons-cli</artifactId>
 			<version>1.2</version>
-			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -109,10 +109,9 @@
 			<!-- scope>runtime</scope-->
 		</dependency>
 		<dependency>
-			<groupId>org.javolution</groupId>
+			<groupId>javolution</groupId>
 			<artifactId>javolution</artifactId>
-			<version>5.2.6</version>
-			<scope>runtime</scope>
+			<version>5.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,10 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+		<maven.compiler.source>1.7</maven.compiler.source>
+		<maven.compiler.target>1.7</maven.compiler.target>
+
 		<cfparser.version>2.4.6</cfparser.version>
 	</properties>
   
@@ -200,15 +204,6 @@
 
 	<build>
 		<plugins>
-		    <plugin>
-		      <groupId>org.apache.maven.plugins</groupId>
-		      <artifactId>maven-compiler-plugin</artifactId>
-		      <version>3.3</version>
-		       <configuration>
-		        <source>1.7</source>
-		        <target>1.7</target>
-		       </configuration>
-		    </plugin>
 			<plugin>
 				<artifactId>maven-dependency-plugin</artifactId>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -93,18 +93,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
-			<artifactId>antlr4-runtime</artifactId>
-			<version>4.7</version>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>stringtemplate</artifactId>
-			<version>4.0.2</version>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
 			<artifactId>antlr4</artifactId>
-			<version>4.6</version>
+			<version>4.7</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>


### PR DESCRIPTION
Following up on a similar pull request cfparser/cfparser#78.

Cleaning the POM of obsolete statements, correcting scopes, moving some versions to `<properties>` to make it easier to keep those in line.

**Importantly** aligning a number of dependencies with the versions used by cfparser/cfparser:

* `org.antlr:antlr4` replaced with 4.7 and removed explicit `stringtemplate` and `antlr4-runtime` dependencies, since these come with the first package
* updated `commons-logging` to 1.2 and `javolution` to 5.5.1, which is what cfparser/cfparser is using, thus removing ugly `maven-shade-plugin` warnings (and hopefully the potential of bugs due to dependency mismatch)

This **must be merged _after_ cfparser/cfparser#78** and with a new version of cfparser/cfparser included. Otherwise the `antlr4` changes will be breaking.