### PR TITLE
Lighten ANTLR dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,8 +93,13 @@
 		</dependency>
 		<dependency>
 			<groupId>org.antlr</groupId>
-			<artifactId>antlr4</artifactId>
+			<artifactId>antlr4-runtime</artifactId>
 			<version>4.7</version>
+		</dependency>
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr-runtime</artifactId>
+			<version>3.5.2</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-logging</groupId>


### PR DESCRIPTION
Matching similar changes in cfparser/cfparser#79.

`antlr4-runtime` and `antlr-runtime` actually come with `cfparser`, but some of the classes here also depend on these, so let's keep them in the POM.

Otherwise, the full `antlr4` package isn't needed and we can slash 10MB of dependencies from the final package this way, by keeping just the runtime dependencies.