### PR TITLE
Remove dependencies defined in cfparser and add git info to artifact.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,49 +72,8 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.github.cfparser</groupId>
-			<artifactId>cfparser</artifactId>
-			<version>${cfparser.version}</version>
-			<type>pom</type>
-		</dependency>
-		<dependency>
-			<groupId>com.github.cfparser</groupId>
 			<artifactId>cfml.parsing</artifactId>
 			<version>${cfparser.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.github.cfparser</groupId>
-			<artifactId>cfml.dictionary</artifactId>
-			<version>${cfparser.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.jdom</groupId>
-			<artifactId>jdom</artifactId>
-			<version>1.1.3</version>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr4-runtime</artifactId>
-			<version>4.7</version>
-		</dependency>
-		<dependency>
-			<groupId>org.antlr</groupId>
-			<artifactId>antlr-runtime</artifactId>
-			<version>3.5.2</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-logging</groupId>
-			<artifactId>commons-logging</artifactId>
-			<version>1.2</version>
-		</dependency>
-		<dependency>
-			<groupId>net.htmlparser.jericho</groupId>
-			<artifactId>jericho-html</artifactId>
-			<version>3.4</version>
-		</dependency>
-		<dependency>
-			<groupId>javolution</groupId>
-			<artifactId>javolution</artifactId>
-			<version>5.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>
@@ -150,16 +109,6 @@
 		  <groupId>com.fasterxml.jackson.module</groupId>
 		  <artifactId>jackson-module-jaxb-annotations</artifactId>
 		  <version>${jackson.version}</version>
-		</dependency>
-		<dependency>
-		    <groupId>org.slf4j</groupId>
-		    <artifactId>slf4j-api</artifactId>
-		    <version>${slf4j.version}</version>
-		</dependency>
-		<dependency>
-		    <groupId>org.slf4j</groupId>
-		    <artifactId>slf4j-simple</artifactId>
-		    <version>${slf4j.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.java.dev.stax-utils</groupId>
@@ -292,6 +241,24 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+	          <groupId>pl.project13.maven</groupId>
+	          <artifactId>git-commit-id-plugin</artifactId>
+	          <version>2.2.2</version>
+	          <executions>
+	              <execution>
+	                  <phase>validate</phase>
+	                  <goals>
+	                      <goal>revision</goal>
+	                  </goals>
+	              </execution>
+	          </executions>
+	          <configuration>
+	              <dateFormat>yyyyMMdd-HHmmss</dateFormat>
+	              <dotGitDirectory>${project.basedir}/.git</dotGitDirectory>
+	              <generateGitPropertiesFile>true</generateGitPropertiesFile>
+	          </configuration>
+	      	</plugin>				
 			<plugin>
 			    <groupId>org.apache.maven.plugins</groupId>
 			    <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
There shouldn't be any need to redefine the dependencies defined in cfparser, so I've removed those, and then while we can add a git hash to the actual build artifact name, it doesn't really play nice with Maven (works fine for p2/Eclipse repositories, but that's besides the point), so the next best thing is to include something that can be parsed by a maven plugin or some such (what this does), so build artifacts will now at least have a git.properties file inside them containing oodles of info about exactly what version was built.