### PR TITLE
Remove dependency copying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,20 +144,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-dependency-plugin</artifactId>
-				<executions>
-					<execution>
-						<phase>process-sources</phase>
-						<goals>
-							<goal>copy-dependencies</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${targetdirectory}</outputDirectory>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>appassembler-maven-plugin</artifactId>
 				<version>1.10</version>


### PR DESCRIPTION
There doesn't seem to be a reason to have this phase. Perhaps there was one before? All the required dependencies are added to the final JAR by the `maven-shade-plugin` in the `package` phase anyway. This dependency copying just seems like a waste of time.

Running `mvn clean verify` without it passes cleanly, all tests succeed and the resulting JAR executes as expected. If I'm missing something, let me know.