### PR TITLE
Align Gradle dependencies with Maven ones

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,20 +37,9 @@ repositories {
     maven { url "http://cfmlprojects.org/artifacts" }
 }
 dependencies {
-    compile group: 'com.github.cfparser', name: 'cfparser', version:'2.4.9'
-    compile group: 'com.github.cfparser', name: 'cfml.parsing', version:'2.4.9'
-    compile group: 'com.github.cfparser', name: 'cfml.dictionary', version:'2.4.9'
-    compile group: 'junit', name: 'junit', version:'4.12'
-    compile group: 'org.jdom', name: 'jdom', version:'1.1.3'
-    compile group: 'org.antlr', name: 'antlr4-runtime', version:'4.7'
-    compile group: 'org.antlr', name: 'stringtemplate', version:'4.0.2'
-    compile group: 'org.antlr', name: 'antlr4', version:'4.6'
-    compile group: 'net.htmlparser.jericho', name: 'jericho-html', version:'3.4'
-    compile group: 'log4j', name: 'log4j', version:'1.2.17'
-    compile group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.5'
+    compile group: 'com.github.cfparser', name: 'cfml.parsing', version:'2.4.10'
     compile group: 'commons-cli', name: 'commons-cli', version:'1.2'
     compile group: 'ro.fortsoft.pf4j', name: 'pf4j', version:'0.6'
-    compile group: 'org.slf4j', name: 'slf4j-log4j12', version:'1.7.5'
     compile group: 'ant', name: 'ant', version:'1.7.0'
     compile group: 'com.sun.xml.bind', name: 'jaxb-impl', version:'2.1.8'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.8.6'
@@ -61,10 +50,8 @@ dependencies {
     }
     // https://mvnrepository.com/artifact/commons-io/commons-io
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
-    
-    runtime group: 'commons-logging', name: 'commons-logging-api', version:'1.1'
-    runtime group: 'org.slf4j', name: 'slf4j-api', version:'1.7.5'
-    runtime group: 'org.javolution', name: 'javolution', version:'5.2.6'
+
+    testCompile group: 'junit', name: 'junit', version:'4.12'
 }
 
 test {


### PR DESCRIPTION
Define the same set (and scopes) of dependencies for Gradle builds as we have now in Maven's `pom.xml`. Also, following the same order as in the POM.