### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Provides [common whitespace settings for all editors](http://editorconfig.org/). Supported out of the box in some IDE's (like IntelliJ IDEA) and all others have appropriate plugins.