### PR TITLE
#390 Add Implementation-Version to MANIFEST

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ jar {
   manifest {
     attributes(
       'Main-Class': 'com.cflint.main.CFLintMain',
+      'Implementation-Version': version,
     )
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,17 @@
 					</execution>
 				</executions>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
 				<version>2.6</version>


### PR DESCRIPTION
Configures the Maven and Gradle builds to include `Implementation-Version` in the MANIFEST.MF file, which can then be read by the application and displayed to the user.