### PR TITLE
382 gradle changelog automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,177 +1,628 @@
-History
-=======
 
-## Overview of major changes in CFLint 1.2.0
 
-### Parsing
+# CHANGE LOG
+
+## [CFLint-1.3.0-RC2](https://github.com/cflint/CFLint/tree/CFLint-1.3.0-RC2) (2017-12-28)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-1.3.0-RC1...CFLint-1.3.0-RC2)
+
+**Implemented enhancements:**
+
+- Parameter name standardization [\#503](https://github.com/cflint/CFLint/issues/503)
+- Implement an api [\#409](https://github.com/cflint/CFLint/issues/409)
+
+**Fixed bugs:**
+
+- java cast exception when parsing include where template argument is a function result [\#506](https://github.com/cflint/CFLint/issues/506)
+- Deprecated message in stdout [\#448](https://github.com/cflint/CFLint/issues/448)
+
+**Closed issues:**
+
+- Provide examples for how to use rule parameters [\#504](https://github.com/cflint/CFLint/issues/504)
+
+**Merged pull requests:**
+
+- Improved some issue messages. [\#502](https://github.com/cflint/CFLint/pull/502) ([KamasamaK](https://github.com/KamasamaK))
+
+## [CFLint-1.3.0-RC1](https://github.com/cflint/CFLint/tree/CFLint-1.3.0-RC1) (2017-12-24)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-1.2.3...CFLint-1.3.0-RC1)
+
+**Implemented enhancements:**
+
+- inline ignore ARG\_TYPE\_MISSING --  support inline ignores at the statement level. [\#497](https://github.com/cflint/CFLint/issues/497)
+- MISSING\_VAR reports for variables inside lock{} [\#488](https://github.com/cflint/CFLint/issues/488)
+- COMPONENT\_\* errors quote displayName instead of filename [\#469](https://github.com/cflint/CFLint/issues/469)
+- Exceptions that occur in plugins \(aka rules\) should not be reported as PARSE\_ERROR [\#358](https://github.com/cflint/CFLint/issues/358)
+- Added more tags and attributes to check in VarScoper [\#495](https://github.com/cflint/CFLint/pull/495) ([KamasamaK](https://github.com/KamasamaK))
+
+**Fixed bugs:**
+
+- unused var, but it is used. [\#493](https://github.com/cflint/CFLint/issues/493)
+- Ignore mechanism not working properly [\#489](https://github.com/cflint/CFLint/issues/489)
+- debug="false" on cfquery reports as leaving debug on tags [\#487](https://github.com/cflint/CFLint/issues/487)
+- MISSING\_VAR reports cfwddx\(\) attributes [\#483](https://github.com/cflint/CFLint/issues/483)
+- MISSING\_VAR reports cfmail\(\) attributes [\#482](https://github.com/cflint/CFLint/issues/482)
+- @CFLintIgnore UNUSED\_METHOD\_ARGUMENT ignored [\#467](https://github.com/cflint/CFLint/issues/467)
+- multiple UNUSED\_LOCAL\_VARIABLE false positives with cflib safeText [\#465](https://github.com/cflint/CFLint/issues/465)
+- Running on folder causes nonexistent issues to be produced [\#463](https://github.com/cflint/CFLint/issues/463)
+- Parsing error on "var no = 1;" [\#442](https://github.com/cflint/CFLint/issues/442)
+- NullPointerException when string contains closing HTML tag without a matching opening one [\#440](https://github.com/cflint/CFLint/issues/440)
+- NullPointerException-s when 'component' word used in function comment in an interface [\#439](https://github.com/cflint/CFLint/issues/439)
+- NullPointerException when calling function 'index' with variable as argument [\#437](https://github.com/cflint/CFLint/issues/437)
+- CFLint JAR became 22MB again [\#420](https://github.com/cflint/CFLint/issues/420)
+- False positive on unused arguments when argument used in query param [\#418](https://github.com/cflint/CFLint/issues/418)
+- False positive unused var when local variable is used in queryparam [\#416](https://github.com/cflint/CFLint/issues/416)
+- MISSING\_VAR in CFLOOP index [\#413](https://github.com/cflint/CFLint/issues/413)
+- UNQUOTED\_STRUCT\_KEY only reported for implicit declaration [\#405](https://github.com/cflint/CFLint/issues/405)
+- MISSING\_VAR not caught for undeclared struct [\#404](https://github.com/cflint/CFLint/issues/404)
+
+**Closed issues:**
+
+- ARG\_VAR\_MIXED reported when implicit struct has key equal to argument [\#478](https://github.com/cflint/CFLint/issues/478)
+- wrong expression for VAR\_HAS\_PREFIX\_OR\_POSTFIX [\#476](https://github.com/cflint/CFLint/issues/476)
+- Variable Query is not a valid name. Please use CamelCase or underscores. [\#472](https://github.com/cflint/CFLint/issues/472)
+- Double NPE with nested array notation [\#452](https://github.com/cflint/CFLint/issues/452)
+- NPE with nested array notation [\#451](https://github.com/cflint/CFLint/issues/451)
+- PLUGIN\_ERROR on dev branch [\#450](https://github.com/cflint/CFLint/issues/450)
+- Execution failed for task ':test'. [\#446](https://github.com/cflint/CFLint/issues/446)
+- Config file usage [\#362](https://github.com/cflint/CFLint/issues/362)
+
+**Merged pull requests:**
+
+- Fixed regression with changing case for settings [\#496](https://github.com/cflint/CFLint/pull/496) ([KamasamaK](https://github.com/KamasamaK))
+- Dev README [\#494](https://github.com/cflint/CFLint/pull/494) ([KamasamaK](https://github.com/KamasamaK))
+- Update README.md [\#484](https://github.com/cflint/CFLint/pull/484) ([cameroncf](https://github.com/cameroncf))
+- Add offset to BugInfo. [\#466](https://github.com/cflint/CFLint/pull/466) ([denuno](https://github.com/denuno))
+- Missing var 404 [\#461](https://github.com/cflint/CFLint/pull/461) ([ryaneberly](https://github.com/ryaneberly))
+- \#405 implemented. [\#460](https://github.com/cflint/CFLint/pull/460) ([ryaneberly](https://github.com/ryaneberly))
+- reformat files to fix white space and minor formatting issues [\#458](https://github.com/cflint/CFLint/pull/458) ([justinmclean](https://github.com/justinmclean))
+- add missing final to method arguments [\#457](https://github.com/cflint/CFLint/pull/457) ([justinmclean](https://github.com/justinmclean))
+- removed unused variables \(mostly severity\) [\#456](https://github.com/cflint/CFLint/pull/456) ([justinmclean](https://github.com/justinmclean))
+- add missing scope \(mostly private\) [\#455](https://github.com/cflint/CFLint/pull/455) ([justinmclean](https://github.com/justinmclean))
+- move CF constants into own file [\#454](https://github.com/cflint/CFLint/pull/454) ([justinmclean](https://github.com/justinmclean))
+- \#450 [\#453](https://github.com/cflint/CFLint/pull/453) ([ryaneberly](https://github.com/ryaneberly))
+- Move settings/options out into it's own file [\#445](https://github.com/cflint/CFLint/pull/445) ([justinmclean](https://github.com/justinmclean))
+- Refactor levels [\#441](https://github.com/cflint/CFLint/pull/441) ([justinmclean](https://github.com/justinmclean))
+
+## [CFLint-1.2.3](https://github.com/cflint/CFLint/tree/CFLint-1.2.3) (2017-08-12)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-1.2.2...CFLint-1.2.3)
+
+**Closed issues:**
+
+- Null pointer Exception [\#408](https://github.com/cflint/CFLint/issues/408)
+
+## [CFLint-1.2.2](https://github.com/cflint/CFLint/tree/CFLint-1.2.2) (2017-08-10)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint1.2.0...CFLint-1.2.2)
+
+### Overview and major changes in [CFLint 1.2.2](https://github.com/cflint/CFLint/tree/CFLint1.2.2)
+
+#### Linting
+
+* Bugfixes for rule processing
+
+#### Output
+
+* Output of some rules has been improved and fixed
+* Internal changes for output processing
+* Timestamp issues in XML output sorted
+* Ducumentation for output schemas
+
+### Details
+
+**Implemented enhancements:**
+
+- Clarify/update documentation for command line use in Powershell [\#400](https://github.com/cflint/CFLint/issues/400)
+- MISSING\_VAR issue in for loop [\#396](https://github.com/cflint/CFLint/issues/396)
+- EXCESSIVE\_FUNCTIONS uses absolute path in message [\#367](https://github.com/cflint/CFLint/issues/367)
+- Document output schemas [\#322](https://github.com/cflint/CFLint/issues/322)
+- Test Harry's Sublime/CFLint instructions and i18n to English if ok [\#307](https://github.com/cflint/CFLint/issues/307)
+
+**Fixed bugs:**
+
+- Gradle builds have stopped \(or never did\) publishing CFLint version number [\#390](https://github.com/cflint/CFLint/issues/390)
+- Timestamp in JSON output should be a number [\#383](https://github.com/cflint/CFLint/issues/383)
+- CFQUERYPARAM\_REQ false positive with mixed case CFqueryparam [\#380](https://github.com/cflint/CFLint/issues/380)
+- Support .cflintrc when using the -stdin argument. [\#373](https://github.com/cflint/CFLint/issues/373)
+- PARSE\_ERROR when concatenating strings with single quotes [\#359](https://github.com/cflint/CFLint/issues/359)
+- PARSE\_ERROR on scoped variable assignment in CFM [\#346](https://github.com/cflint/CFLint/issues/346)
+
+**Closed issues:**
+
+- PACKAGE\_CASE\_MISMATCH is reporting line 1 instead of actual. [\#402](https://github.com/cflint/CFLint/issues/402)
+- Document .cflintrc schema [\#352](https://github.com/cflint/CFLint/issues/352)
+- Document IDE integrations [\#312](https://github.com/cflint/CFLint/issues/312)
+
+**Merged pull requests:**
+
+- Dev prep 1.2.1 release [\#415](https://github.com/cflint/CFLint/pull/415) ([ryaneberly](https://github.com/ryaneberly))
+- Added VS Code info. Some cleanup. [\#403](https://github.com/cflint/CFLint/pull/403) ([KamasamaK](https://github.com/KamasamaK))
+- Update README.md [\#401](https://github.com/cflint/CFLint/pull/401) ([Ilaeria](https://github.com/Ilaeria))
+- \#390 - Review changes [\#399](https://github.com/cflint/CFLint/pull/399) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- \#390 - Hopefully fixing Gradle build [\#397](https://github.com/cflint/CFLint/pull/397) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- \#390 - Adapting new way to grab version string [\#395](https://github.com/cflint/CFLint/pull/395) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- \#385 - Further HTML report improvements [\#394](https://github.com/cflint/CFLint/pull/394) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- \#390 Add Implementation-Version to MANIFEST [\#393](https://github.com/cflint/CFLint/pull/393) ([mpaluchowski](https://github.com/mpaluchowski))
+- Changed build versions to 1.2.1-SNAPSHOT in dev branch and change doc… [\#389](https://github.com/cflint/CFLint/pull/389) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Dev [\#388](https://github.com/cflint/CFLint/pull/388) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Update timestamp type in result schemas [\#387](https://github.com/cflint/CFLint/pull/387) ([KamasamaK](https://github.com/KamasamaK))
+- Dev [\#386](https://github.com/cflint/CFLint/pull/386) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Dev [\#384](https://github.com/cflint/CFLint/pull/384) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Merging commit 8a7a538 from dev [\#381](https://github.com/cflint/CFLint/pull/381) ([KamasamaK](https://github.com/KamasamaK))
+- Add .editorconfig [\#379](https://github.com/cflint/CFLint/pull/379) ([mpaluchowski](https://github.com/mpaluchowski))
+- Align Gradle dependencies with Maven ones [\#378](https://github.com/cflint/CFLint/pull/378) ([mpaluchowski](https://github.com/mpaluchowski))
+-  Added .cflintrc schema and output schemas for JSON and XML. Tweaked README. [\#377](https://github.com/cflint/CFLint/pull/377) ([KamasamaK](https://github.com/KamasamaK))
+
+## [CFLint1.2.0](https://github.com/cflint/CFLint/tree/CFLint1.2.0) (2017-07-29)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-1.0.1...CFLint1.2.0)
+
+### Overview and major changes in [CFLint 1.2.0](https://github.com/cflint/CFLint/tree/CFLint1.2.0)
+
+#### Parsing
 
 * Numerous fixes for parsing CFML code, update to CFParser 2.4.10
 * Upgrade to ANTLR 4.7
 
-### Linting
+#### Linting
 
 * Bugfixes for rule processing
 * Added annotation-based ignoring of rules inline in code.
 * JSON-based configuration has undergone a few changes and configuration properties have been deprecated.
 
-### Output
+#### Output
 
 * Support for -showStats has been removed - scanning statistics are now always produced and displayed/included 
 * Findbugs XML output now matches the requirements for Findbugs' bugcollection.xsd and has undergone major changes from earlier versions.
 * CFLint XML output has some additional attributes for some XML elements in the output structure (no breaking changes)
 * JSON output has undergone a rework of the existing data structure to cater for the output of additional information (breaking changes)
 
+### Details
 
-## CFLint1.2.0 
-##### GitHub [#152](https://github.com/cflint/CFLint/issues/152) UNUSED_METHOD_ARGUMENT ignores scoped arguments
-##### GitHub [#158](https://github.com/cflint/CFLint/issues/158) multiple location members in JSON output
-##### GitHub [#171](https://github.com/cflint/CFLint/issues/171) XML Output : MalformedByteSequenceException: Invalid byte 1 of 1-byte UTF-8 sequence
-##### GitHub [#173](https://github.com/cflint/CFLint/issues/173) Exclude rule for all INFO severity messages, excludes all messages
-##### GitHub [#179](https://github.com/cflint/CFLint/issues/179) CFLint - wrong line number in XML report
-##### GitHub [#182](https://github.com/cflint/CFLint/issues/182) Named arguments in functions
-##### GitHub [#185](https://github.com/cflint/CFLint/issues/185) configfile excludes rules
-##### GitHub [#186](https://github.com/cflint/CFLint/issues/186) Doesn&#39;t seem to be checking missing_var on cfscript cfcs
-##### GitHub [#192](https://github.com/cflint/CFLint/issues/192) Directory Scan
-##### GitHub [#194](https://github.com/cflint/CFLint/issues/194) Config system for includes/excludes is misleading (or broken)
-##### GitHub [#195](https://github.com/cflint/CFLint/issues/195) Support a way to ignore found issues in the future.
-##### GitHub [#197](https://github.com/cflint/CFLint/issues/197) False positive: structure keys reported as variables without scope prefix
-##### GitHub [#198](https://github.com/cflint/CFLint/issues/198) New rule for specifying structure key names in quotation marks
-##### GitHub [#199](https://github.com/cflint/CFLint/issues/199) Rules reporting missing hints should work with script-style code
-##### GitHub [#208](https://github.com/cflint/CFLint/issues/208) Incorrect line number in XML export when previously scanned CFML-based file
-##### GitHub [#211](https://github.com/cflint/CFLint/issues/211) False positive variable used in loop reported as unused
-##### GitHub [#212](https://github.com/cflint/CFLint/issues/212) Where does cflint-ui come from?
-##### GitHub [#220](https://github.com/cflint/CFLint/issues/220) Linter does not check code inside cfscript try/catch/finally blocks
-##### GitHub [#223](https://github.com/cflint/CFLint/issues/223) Duplicate &quot;Temporary variable could be named better&quot; warnings
-##### GitHub [#243](https://github.com/cflint/CFLint/issues/243) Parse error when multiple spaces in CFML tag
-##### GitHub [#253](https://github.com/cflint/CFLint/issues/253) CFML analysis tries to parse tags inside strings/literals
-##### GitHub [#254](https://github.com/cflint/CFLint/issues/254) Variable Prefix and Postfix - More dynamic
-##### GitHub [#256](https://github.com/cflint/CFLint/issues/256) Var &#39;declared&#39; with local scope.
-##### GitHub [#257](https://github.com/cflint/CFLint/issues/257) Does not see argument as used when it is used in brackets inside of function.
-##### GitHub [#260](https://github.com/cflint/CFLint/issues/260) Default Rules merging with config.xml
-##### GitHub [#262](https://github.com/cflint/CFLint/issues/262) feaure: flag use of isDate() 
-##### GitHub [#265](https://github.com/cflint/CFLint/issues/265) Identifier cfcatch is global, referencing in a CFC or function should be avoided.
-##### GitHub [#267](https://github.com/cflint/CFLint/issues/267) Is it possible for dot paths to alert when case doesn&#39;t match
-##### GitHub [#269](https://github.com/cflint/CFLint/issues/269) Unclear error messages: Error in plugin, 0
-##### GitHub [#271](https://github.com/cflint/CFLint/issues/271) Findbugs XML output creates &lt;?xml...?&gt; tag twice
-##### GitHub [#272](https://github.com/cflint/CFLint/pull/272) Fix for #271
-##### GitHub [#278](https://github.com/cflint/CFLint/issues/278) Additions to CFLint XML (was: Building a mechanism to pass timestamps and additional counters into FIndbugs XML)
-##### GitHub [#282](https://github.com/cflint/CFLint/issues/282) CFQUERYPARAM_REQ false positives
-##### GitHub [#284](https://github.com/cflint/CFLint/issues/284) MISSING_VAR false positive cfquery loops
-##### GitHub [#285](https://github.com/cflint/CFLint/issues/285) Script ignore syntax fails in mixed cfscript/tag code
-##### GitHub [#290](https://github.com/cflint/CFLint/issues/290) How to use .cflintrc to ignore a directory?
-##### GitHub [#291](https://github.com/cflint/CFLint/issues/291) Empty files report FILE_ERROR
-##### GitHub [#293](https://github.com/cflint/CFLint/issues/293) Stack overflow in dev branch
-##### GitHub [#295](https://github.com/cflint/CFLint/issues/295) Allowing to ignore CFQUERYPARAM_REQ with SQL code
-##### GitHub [#296](https://github.com/cflint/CFLint/pull/296) Retrospective fix for test case for #282 (and reopened #195)
-##### GitHub [#299](https://github.com/cflint/CFLint/issues/299) Move old bug count logic for output into cflintstats
-##### GitHub [#300](https://github.com/cflint/CFLint/issues/300) XML output with findbugs style should have -showStats set implicitly
-##### GitHub [#301](https://github.com/cflint/CFLint/issues/301) HTML outputs are broken
-##### GitHub [#303](https://github.com/cflint/CFLint/issues/303) Findbugs: totalsize should be lines of code scanned
-##### GitHub [#315](https://github.com/cflint/CFLint/issues/315) inheritPlugins in .cflintrc should be always true 
-##### GitHub [#318](https://github.com/cflint/CFLint/issues/318) JSON output questions (int/string and locations array)
-##### GitHub [#321](https://github.com/cflint/CFLint/pull/321) 290 parse error
-##### GitHub [#323](https://github.com/cflint/CFLint/issues/323) Various smaller issues with output 
-##### GitHub [#326](https://github.com/cflint/CFLint/issues/326) CFLint reporting a column that doesn&#39;t exist
-##### GitHub [#330](https://github.com/cflint/CFLint/issues/330) DefaultCFLintMarshaller doesn&#39;t have any of the CFLint XML improvements in XMLOutput
-##### GitHub [#336](https://github.com/cflint/CFLint/issues/336) AVOID_EMPTY_FILES being reported if file doesn&#39;t exist
-##### GitHub [#339](https://github.com/cflint/CFLint/issues/339) Rule UNUSED_LOCAL_VARIABLE has issues with several tags
-##### GitHub [#340](https://github.com/cflint/CFLint/issues/340) GLOBAL_LITERAL_VALUE_USED_TOO_OFTEN triggered on CF_SQL_
-##### GitHub [#341](https://github.com/cflint/CFLint/pull/341) Fix for test fail on case-insensitive filesystems
-##### GitHub [#343](https://github.com/cflint/CFLint/pull/343) Lighten ANTLR dependencies
-##### GitHub [#344](https://github.com/cflint/CFLint/issues/344) GLOBAL_LITERAL_VALUE_USED_TOO_OFTEN triggered by built in function arguments
-##### GitHub [#345](https://github.com/cflint/CFLint/issues/345) GLOBAL_LITERAL_VALUE_USED_TOO_OFTEN falsely indicated in CFM files with &lt;cfinclude&gt;
-##### GitHub [#347](https://github.com/cflint/CFLint/issues/347) PARSE_ERROR on component with a name coinciding with one instantiated elsewhere
-##### GitHub [#348](https://github.com/cflint/CFLint/pull/348) Update to cfparser 2.4.9
-##### GitHub [#352](https://github.com/cflint/CFLint/issues/352) Document .cflintrc schema
-##### GitHub [#353](https://github.com/cflint/CFLint/pull/353) Dev
-##### GitHub [#356](https://github.com/cflint/CFLint/issues/356) Remove and deprecate &quot;output&quot; on top-level of .cflintrc
-##### GitHub [#357](https://github.com/cflint/CFLint/issues/357) PARSE_ERROR when cfloop has &quot;delimiters&quot; attribute
-##### GitHub [#359](https://github.com/cflint/CFLint/issues/359) PARSE_ERROR when concatenating strings with single quotes
-##### GitHub [#361](https://github.com/cflint/CFLint/issues/361) Add contributing guidelines document
-##### GitHub [#362](https://github.com/cflint/CFLint/issues/362) Config file usage
-##### GitHub [#363](https://github.com/cflint/CFLint/issues/363) Maven build fails using the ZIP file from GitHub since it needs the `.git` folder
-##### GitHub [#366](https://github.com/cflint/CFLint/issues/366) ANTLR Tool version 4.6 mismatch
-##### GitHub [#370](https://github.com/cflint/CFLint/pull/370) #323 - Changing JSON structure and changing expected test results
-## CFLint-1.0.1 
-##### GitHub [#103](https://github.com/cflint/CFLint/issues/103) Enhancement: Enable default config file when parsing similar to other linters
-##### GitHub [#114](https://github.com/cflint/CFLint/issues/114) Group and decide which linting rules to include by default.
-##### GitHub [#194](https://github.com/cflint/CFLint/issues/194) Config system for includes/excludes is misleading (or broken)
-##### GitHub [#222](https://github.com/cflint/CFLint/issues/222) &quot;if&quot; without an &quot;else&quot; triggers &quot;Nothing to parse&quot; warning
-##### GitHub [#224](https://github.com/cflint/CFLint/issues/224) --version should include CFParser version
-##### GitHub [#226](https://github.com/cflint/CFLint/issues/226) infinite loop in recent builds, triggering segmentation fault
-##### GitHub [#227](https://github.com/cflint/CFLint/issues/227) False positive for unused argument when argument is scoped
-##### GitHub [#228](https://github.com/cflint/CFLint/issues/228) Multiple code: is not configured correctly
-##### GitHub [#229](https://github.com/cflint/CFLint/issues/229) Parsing error with nested if()?
-##### GitHub [#230](https://github.com/cflint/CFLint/issues/230) Incorrect error in line 0 when CFML parsing encounters cfscript-like not-equals
-##### GitHub [#234](https://github.com/cflint/CFLint/issues/234) Not accounting for switch statements
-##### GitHub [#235](https://github.com/cflint/CFLint/pull/235) Add a Codacy badge to README.md
-##### GitHub [#239](https://github.com/cflint/CFLint/issues/239) Ignore VAR_ALL_CAPS for components
-##### GitHub [#241](https://github.com/cflint/CFLint/issues/241) XML report includes semicolon after PLUGIN_ERROR id and message
-##### GitHub [#242](https://github.com/cflint/CFLint/issues/242) Should recognize variables used with differing case
-##### GitHub [#244](https://github.com/cflint/CFLint/issues/244) PLUGIN_ERROR on assignment to camel-case variable
-##### GitHub [#245](https://github.com/cflint/CFLint/issues/245) Incorrect PLUGIN_ERROR issue ID with appended exception name
-##### GitHub [#246](https://github.com/cflint/CFLint/issues/246) Detect when assigning to a variable declared as component property
-##### GitHub [#247](https://github.com/cflint/CFLint/pull/247) Update SureFire argLine
-##### GitHub [#248](https://github.com/cflint/CFLint/issues/248) Component name missing from message for COMPONENT_INVALID_NAME
-##### GitHub [#250](https://github.com/cflint/CFLint/issues/250) Analysis tripped up over UTF-8 files with BOM
-## CFLint-0.6.1 
-## v0.6.0 
-##### GitHub [#104](https://github.com/cflint/CFLint/issues/104) Weird messaging for missing semicolon
-##### GitHub [#105](https://github.com/cflint/CFLint/issues/105) Warnings for non-existing errors and non-lint errors before output.
-##### GitHub [#62](https://github.com/cflint/CFLint/issues/62) JSON output
-##### GitHub [#67](https://github.com/cflint/CFLint/issues/67) Gradle Install
-##### GitHub [#80](https://github.com/cflint/CFLint/issues/80) Gradle Deployment
-##### GitHub [#95](https://github.com/cflint/CFLint/issues/95) support json config instead of xml
-## CFLint0.5.1 
-##### GitHub [#65](https://github.com/cflint/CFLint/issues/65) Problem with dynamic table and field names
-##### GitHub [#66](https://github.com/cflint/CFLint/issues/66) cflint-disable / cflint-enable ?
-##### GitHub [#71](https://github.com/cflint/CFLint/issues/71) Unable to exclude rules
-##### GitHub [#89](https://github.com/cflint/CFLint/pull/89) Rule to check for writeDump in cfset tags and script blocks
-##### GitHub [#97](https://github.com/cflint/CFLint/issues/97) Release 0.5.1-SNAPSHOT
-## v0.5 
-##### GitHub [#33](https://github.com/cflint/CFLint/issues/33) no cflint version could be extracted with SublimeLinter
-##### GitHub [#35](https://github.com/cflint/CFLint/issues/35) CFLint Should Download Latest Version of CFParser
-##### GitHub [#36](https://github.com/cflint/CFLint/issues/36) Add Ability to Preview CFParser Snapshots from Sonatype.
-##### GitHub [#38](https://github.com/cflint/CFLint/issues/38) CFLint-ui asking for 4G of Memory
-##### GitHub [#42](https://github.com/cflint/CFLint/issues/42) maven build instructions should address common distribution requirements
-##### GitHub [#45](https://github.com/cflint/CFLint/issues/45) Lint of cfprocresult fails in function when array is used.
-##### GitHub [#49](https://github.com/cflint/CFLint/issues/49) Unable to Parse QueryExecute Functions
-##### GitHub [#51](https://github.com/cflint/CFLint/issues/51) maven install should install the binaries in a usable way
-##### GitHub [#56](https://github.com/cflint/CFLint/issues/56) Build failure
-##### GitHub [#58](https://github.com/cflint/CFLint/issues/58) change license to BSD
-##### GitHub [#59](https://github.com/cflint/CFLint/issues/59) Issue with pom.xml file
-##### GitHub [#60](https://github.com/cflint/CFLint/issues/60) Having trouble using filterFile
-##### GitHub [#62](https://github.com/cflint/CFLint/issues/62) JSON output
-##### GitHub [#63](https://github.com/cflint/CFLint/issues/63) Release v0.5.0
-## CFLint-0.4-release 
-##### GitHub [#19](https://github.com/cflint/CFLint/issues/19) Convert bugs.add() to a plugin format.
-##### GitHub [#21](https://github.com/cflint/CFLint/issues/21) &lt;cfset/&gt; on multiple lines does not process
-##### GitHub [#24](https://github.com/cflint/CFLint/issues/24) parse error &quot;can&#39;t look backwards more than one token in this stream&quot;
-##### GitHub [#25](https://github.com/cflint/CFLint/issues/25) Default cflintexclude.json should only ignore MISSING_VAR&#39;s in init() functions, other violations should NOT be ignored
-##### GitHub [#26](https://github.com/cflint/CFLint/issues/26)  QUERYPARAM_REQ message should reflect the cf tag version not the cf script version.
-##### GitHub [#27](https://github.com/cflint/CFLint/issues/27) Maven build fails with error.
-##### GitHub [#30](https://github.com/cflint/CFLint/issues/30) NESTED_CFOUTPUT false positive
-##### GitHub [#31](https://github.com/cflint/CFLint/issues/31) Trying out the configfile from the command line and getting errors
-## CFLint-0.4 
-##### No issue
-## CFLint-0.3.0 
-##### No issue
-## CFLint-0.2.0 
-##### GitHub [#11](https://github.com/cflint/CFLint/issues/11) Multiple exceptions in output
-##### GitHub [#2](https://github.com/cflint/CFLint/issues/2) Specifying -textfile as an argument, implies -text should be set.
-##### GitHub [#4](https://github.com/cflint/CFLint/issues/4) It would be useful to have a -q (--quiet) option
-##### GitHub [#6](https://github.com/cflint/CFLint/issues/6) Add -version flag
-##### GitHub [#7](https://github.com/cflint/CFLint/issues/7) Add severity level to each issue in stdout
-##### GitHub [#8](https://github.com/cflint/CFLint/issues/8) does not support tagless components
-## CFLint-0.1.8 
-##### No issue
-## CFLint-0.1.6 
-##### GitHub [#1](https://github.com/cflint/CFLint/issues/1) ignore .cfm~ files
-## CFLint-0.1.5 
-##### No issue
-## CFLint-0.1.4 
-##### No issue
-## CFLint-0.1.3 
-##### No issue
-## CFLint-0.1.2 
-##### No issue
+**Implemented enhancements:**
+
+- ANTLR Tool version 4.6 mismatch [\#366](https://github.com/cflint/CFLint/issues/366)
+- inheritPlugins in .cflintrc should be always true  [\#315](https://github.com/cflint/CFLint/issues/315)
+- HTML outputs are broken [\#301](https://github.com/cflint/CFLint/issues/301)
+- Move old bug count logic for output into cflintstats [\#299](https://github.com/cflint/CFLint/issues/299)
+- Allowing to ignore CFQUERYPARAM\_REQ with SQL code [\#295](https://github.com/cflint/CFLint/issues/295)
+- Empty files report FILE\_ERROR [\#291](https://github.com/cflint/CFLint/issues/291)
+- Additions to CFLint XML \(was: Building a mechanism to pass timestamps and additional counters into FIndbugs XML\) [\#278](https://github.com/cflint/CFLint/issues/278)
+- Additional improvements necessary for issues XML to be XML transformed into more meaningful Findbugs XML  [\#276](https://github.com/cflint/CFLint/issues/276)
+- Generated findbugs xml report doesn't adhere to Findbugs XML Schema [\#274](https://github.com/cflint/CFLint/issues/274)
+- We need this to run for Visual Studio Code also. [\#270](https://github.com/cflint/CFLint/issues/270)
+- npm install [\#268](https://github.com/cflint/CFLint/issues/268)
+
+**Fixed bugs:**
+
+- PARSE\_ERROR when "function" used as variable name [\#364](https://github.com/cflint/CFLint/issues/364)
+- Rule UNUSED\_LOCAL\_VARIABLE has issues with several tags [\#339](https://github.com/cflint/CFLint/issues/339)
+- AVOID\_EMPTY\_FILES being reported if file doesn't exist [\#336](https://github.com/cflint/CFLint/issues/336)
+- DefaultCFLintMarshaller doesn't have any of the CFLint XML improvements in XMLOutput [\#330](https://github.com/cflint/CFLint/issues/330)
+- EXCESSIVE\_ARGUMENTS is not configured correctly [\#308](https://github.com/cflint/CFLint/issues/308)
+- HTML outputs are broken [\#301](https://github.com/cflint/CFLint/issues/301)
+- Stack overflow in dev branch [\#293](https://github.com/cflint/CFLint/issues/293)
+- MISSING\_SEMI false positive in if/else [\#289](https://github.com/cflint/CFLint/issues/289)
+- Script ignore syntax fails in mixed cfscript/tag code [\#285](https://github.com/cflint/CFLint/issues/285)
+- MISSING\_VAR false positive cfquery loops [\#284](https://github.com/cflint/CFLint/issues/284)
+- CFQUERYPARAM\_REQ false positives [\#282](https://github.com/cflint/CFLint/issues/282)
+- Generated findbugs xml report doesn't adhere to Findbugs XML Schema [\#274](https://github.com/cflint/CFLint/issues/274)
+- Findbugs XML output creates \<?xml...?\> tag twice [\#271](https://github.com/cflint/CFLint/issues/271)
+- Unclear error messages: Error in plugin, 0 [\#269](https://github.com/cflint/CFLint/issues/269)
+- Complex if\(\) freezes analysis [\#266](https://github.com/cflint/CFLint/issues/266)
+- CFML analysis tries to parse tags inside strings/literals [\#253](https://github.com/cflint/CFLint/issues/253)
+
+**Closed issues:**
+
+- Maven build fails using the ZIP file from GitHub since it needs the `.git` folder [\#363](https://github.com/cflint/CFLint/issues/363)
+- Add contributing guidelines document [\#361](https://github.com/cflint/CFLint/issues/361)
+- PARSE\_ERROR when cfloop has "delimiters" attribute [\#357](https://github.com/cflint/CFLint/issues/357)
+- Remove and deprecate "output" on top-level of .cflintrc [\#356](https://github.com/cflint/CFLint/issues/356)
+- PARSE\_ERROR on component with a name coinciding with one instantiated elsewhere [\#347](https://github.com/cflint/CFLint/issues/347)
+- GLOBAL\_LITERAL\_VALUE\_USED\_TOO\_OFTEN falsely indicated in CFM files with \<cfinclude\> [\#345](https://github.com/cflint/CFLint/issues/345)
+- GLOBAL\_LITERAL\_VALUE\_USED\_TOO\_OFTEN triggered by built in function arguments [\#344](https://github.com/cflint/CFLint/issues/344)
+- GLOBAL\_LITERAL\_VALUE\_USED\_TOO\_OFTEN triggered on CF\_SQL\_ [\#340](https://github.com/cflint/CFLint/issues/340)
+- CFLint reporting a column that doesn't exist [\#326](https://github.com/cflint/CFLint/issues/326)
+- Various smaller issues with output  [\#323](https://github.com/cflint/CFLint/issues/323)
+- JSON output questions \(int/string and locations array\) [\#318](https://github.com/cflint/CFLint/issues/318)
+- Add \#cflint channel on Slack CFML [\#309](https://github.com/cflint/CFLint/issues/309)
+- Findbugs: totalsize should be lines of code scanned [\#303](https://github.com/cflint/CFLint/issues/303)
+- CFQUERYPARAM\_REQ false positive: String in SQL Server XML function [\#297](https://github.com/cflint/CFLint/issues/297)
+- Identifier cfcatch is global, referencing in a CFC or function should be avoided. [\#265](https://github.com/cflint/CFLint/issues/265)
+- Parse errors when last element in structure has trailing comma [\#263](https://github.com/cflint/CFLint/issues/263)
+- feaure: flag use of isDate\(\)  [\#262](https://github.com/cflint/CFLint/issues/262)
+- cfscript version of calling stored proc giving errors with correct code. [\#261](https://github.com/cflint/CFLint/issues/261)
+- Default Rules merging with config.xml [\#260](https://github.com/cflint/CFLint/issues/260)
+- Parse error for method calls with certain names including contains and import. [\#258](https://github.com/cflint/CFLint/issues/258)
+- Does not see argument as used when it is used in brackets inside of function. [\#257](https://github.com/cflint/CFLint/issues/257)
+- Var 'declared' with local scope. [\#256](https://github.com/cflint/CFLint/issues/256)
+- unsused local variable rule does not handle cfinclude [\#255](https://github.com/cflint/CFLint/issues/255)
+- Variable Prefix and Postfix - More dynamic [\#254](https://github.com/cflint/CFLint/issues/254)
+- cfset with var and square brackets causes PARSE\_ERROR [\#252](https://github.com/cflint/CFLint/issues/252)
+- Graceful handling of semicolon missing at end of return statement [\#251](https://github.com/cflint/CFLint/issues/251)
+- Parse error when multiple spaces in CFML tag [\#243](https://github.com/cflint/CFLint/issues/243)
+- Support a way to ignore found issues in the future. [\#195](https://github.com/cflint/CFLint/issues/195)
+
+**Merged pull requests:**
+
+- Remove dependency copying [\#376](https://github.com/cflint/CFLint/pull/376) ([mpaluchowski](https://github.com/mpaluchowski))
+- Dev [\#375](https://github.com/cflint/CFLint/pull/375) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- \#323 - Changing JSON structure and changing expected test results [\#370](https://github.com/cflint/CFLint/pull/370) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Various... [\#369](https://github.com/cflint/CFLint/pull/369) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Dev [\#360](https://github.com/cflint/CFLint/pull/360) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Dev [\#353](https://github.com/cflint/CFLint/pull/353) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- More documentation [\#351](https://github.com/cflint/CFLint/pull/351) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Some initial changes and content moving from Wiki into README for 1.2… [\#350](https://github.com/cflint/CFLint/pull/350) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Remove dependencies defined in cfparser and add git info to artifact. [\#349](https://github.com/cflint/CFLint/pull/349) ([denuno](https://github.com/denuno))
+- Update to cfparser 2.4.9 [\#348](https://github.com/cflint/CFLint/pull/348) ([mpaluchowski](https://github.com/mpaluchowski))
+- Lighten ANTLR dependencies [\#343](https://github.com/cflint/CFLint/pull/343) ([mpaluchowski](https://github.com/mpaluchowski))
+- Put .cflintrc back into Parsing directory for test. Was missing after… [\#342](https://github.com/cflint/CFLint/pull/342) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Fix for test fail on case-insensitive filesystems [\#341](https://github.com/cflint/CFLint/pull/341) ([mpaluchowski](https://github.com/mpaluchowski))
+- POM dependency cleanup [\#338](https://github.com/cflint/CFLint/pull/338) ([mpaluchowski](https://github.com/mpaluchowski))
+- Updated to 1.2.0 in gradle.properties [\#337](https://github.com/cflint/CFLint/pull/337) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Updated pom in dev for 1.2.0-SNAPSHOT [\#335](https://github.com/cflint/CFLint/pull/335) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Dev [\#334](https://github.com/cflint/CFLint/pull/334) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- \#315 forcing inheritPluhins to be true [\#333](https://github.com/cflint/CFLint/pull/333) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- 323 and 330 [\#332](https://github.com/cflint/CFLint/pull/332) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- 300 remove show stats [\#325](https://github.com/cflint/CFLint/pull/325) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- 318 json output fixes [\#324](https://github.com/cflint/CFLint/pull/324) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- 290 parse error [\#321](https://github.com/cflint/CFLint/pull/321) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- 299 refactoring stats [\#320](https://github.com/cflint/CFLint/pull/320) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- \#303 Remaining fixes [\#305](https://github.com/cflint/CFLint/pull/305) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- 301 - html report fixes [\#304](https://github.com/cflint/CFLint/pull/304) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Partial fix for \#301 [\#302](https://github.com/cflint/CFLint/pull/302) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Work on \#278, Improving Findbugs XML output with stats counts and timestamp [\#298](https://github.com/cflint/CFLint/pull/298) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Retrospective fix for test case for \#282 \(and reopened \#195\) [\#296](https://github.com/cflint/CFLint/pull/296) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Cherry-picked and cleaned up @denuno's fix for \#285 [\#294](https://github.com/cflint/CFLint/pull/294) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Testcase for \#285 [\#287](https://github.com/cflint/CFLint/pull/287) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Added testcase for \#195 \(ignoring rules\) not working [\#283](https://github.com/cflint/CFLint/pull/283) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- PR for master-\>dev merge [\#281](https://github.com/cflint/CFLint/pull/281) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- 276 findbugs improvement [\#280](https://github.com/cflint/CFLint/pull/280) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- 275 remove old xsl [\#279](https://github.com/cflint/CFLint/pull/279) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- \#274 findbugs schema fixes [\#277](https://github.com/cflint/CFLint/pull/277) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Fix for \#271 [\#272](https://github.com/cflint/CFLint/pull/272) ([TheRealAgentK](https://github.com/TheRealAgentK))
+
+## [CFLint-1.0.1](https://github.com/cflint/CFLint/tree/CFLint-1.0.1) (2017-03-13)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.6.1...CFLint-1.0.1)
+
+**Implemented enhancements:**
+
+- Gradle Deployment [\#80](https://github.com/cflint/CFLint/issues/80)
+- JavaDocs [\#61](https://github.com/cflint/CFLint/issues/61)
+
+**Closed issues:**
+
+- Analysis tripped up over UTF-8 files with BOM [\#250](https://github.com/cflint/CFLint/issues/250)
+- Using 'function' as shorthand structure key causes a parsing error [\#249](https://github.com/cflint/CFLint/issues/249)
+- Component name missing from message for COMPONENT\_INVALID\_NAME [\#248](https://github.com/cflint/CFLint/issues/248)
+- Detect when assigning to a variable declared as component property [\#246](https://github.com/cflint/CFLint/issues/246)
+- Incorrect PLUGIN\_ERROR issue ID with appended exception name [\#245](https://github.com/cflint/CFLint/issues/245)
+- PLUGIN\_ERROR on assignment to camel-case variable [\#244](https://github.com/cflint/CFLint/issues/244)
+- Should recognize variables used with differing case [\#242](https://github.com/cflint/CFLint/issues/242)
+- XML report includes semicolon after PLUGIN\_ERROR id and message [\#241](https://github.com/cflint/CFLint/issues/241)
+- Escaped hashes in CFM files cause PLUGIN\_ERROR [\#240](https://github.com/cflint/CFLint/issues/240)
+- Ignore VAR\_ALL\_CAPS for components [\#239](https://github.com/cflint/CFLint/issues/239)
+- cflint/cfparser not handling the script version of cfmail correctly. [\#237](https://github.com/cflint/CFLint/issues/237)
+- Parsing cfscript functions with hints renders multiple errors. [\#236](https://github.com/cflint/CFLint/issues/236)
+- Not accounting for switch statements [\#234](https://github.com/cflint/CFLint/issues/234)
+- Parse error using comparison operators in struct assignment [\#233](https://github.com/cflint/CFLint/issues/233)
+- Parse error using Elvis operator in struct assignment [\#232](https://github.com/cflint/CFLint/issues/232)
+- Combine the config and the filter file [\#231](https://github.com/cflint/CFLint/issues/231)
+- Incorrect error in line 0 when CFML parsing encounters cfscript-like not-equals [\#230](https://github.com/cflint/CFLint/issues/230)
+- Parsing error with nested if\(\)? [\#229](https://github.com/cflint/CFLint/issues/229)
+- Multiple code: is not configured correctly [\#228](https://github.com/cflint/CFLint/issues/228)
+- False positive for unused argument when argument is scoped [\#227](https://github.com/cflint/CFLint/issues/227)
+- infinite loop in recent builds, triggering segmentation fault [\#226](https://github.com/cflint/CFLint/issues/226)
+- --version should include CFParser version [\#224](https://github.com/cflint/CFLint/issues/224)
+- Duplicate "Temporary variable could be named better" warnings [\#223](https://github.com/cflint/CFLint/issues/223)
+- "if" without an "else" triggers "Nothing to parse" warning [\#222](https://github.com/cflint/CFLint/issues/222)
+- Linter does not check code inside cfscript try/catch/finally blocks [\#220](https://github.com/cflint/CFLint/issues/220)
+- Thank you [\#219](https://github.com/cflint/CFLint/issues/219)
+- Where does cflint-ui come from? [\#212](https://github.com/cflint/CFLint/issues/212)
+- False positive variable used in loop reported as unused [\#211](https://github.com/cflint/CFLint/issues/211)
+- False positive when named arguments in function call enclosed in quotes [\#210](https://github.com/cflint/CFLint/issues/210)
+- False positive when return statement contains assignment [\#209](https://github.com/cflint/CFLint/issues/209)
+- Incorrect line number in XML export when previously scanned CFML-based file [\#208](https://github.com/cflint/CFLint/issues/208)
+- can't parse param syntax without attribute names [\#207](https://github.com/cflint/CFLint/issues/207)
+- Stackoverflow with execute\(\) function [\#200](https://github.com/cflint/CFLint/issues/200)
+- Rules reporting missing hints should work with script-style code [\#199](https://github.com/cflint/CFLint/issues/199)
+- New rule for specifying structure key names in quotation marks [\#198](https://github.com/cflint/CFLint/issues/198)
+- False positive: structure keys reported as variables without scope prefix [\#197](https://github.com/cflint/CFLint/issues/197)
+- Config system for includes/excludes is misleading \(or broken\) [\#194](https://github.com/cflint/CFLint/issues/194)
+- Directory Scan [\#192](https://github.com/cflint/CFLint/issues/192)
+- Doesn't seem to be checking missing\_var on cfscript cfcs [\#186](https://github.com/cflint/CFLint/issues/186)
+- configfile excludes rules [\#185](https://github.com/cflint/CFLint/issues/185)
+- writeDump arguments not recognised correctly [\#183](https://github.com/cflint/CFLint/issues/183)
+- Named arguments in functions [\#182](https://github.com/cflint/CFLint/issues/182)
+- CFLint - wrong line number in XML report [\#179](https://github.com/cflint/CFLint/issues/179)
+- incompatible types: cfml.parsing.cfscript.CFIdentifier cannot be converted to java.lang.String [\#178](https://github.com/cflint/CFLint/issues/178)
+- Errors: property & array returntype [\#177](https://github.com/cflint/CFLint/issues/177)
+- cfmodule [\#176](https://github.com/cflint/CFLint/issues/176)
+- Exclude rule for all INFO severity messages, excludes all messages [\#173](https://github.com/cflint/CFLint/issues/173)
+- XML Output : MalformedByteSequenceException: Invalid byte 1 of 1-byte UTF-8 sequence [\#171](https://github.com/cflint/CFLint/issues/171)
+- Build Error on dev b359dae [\#169](https://github.com/cflint/CFLint/issues/169)
+- multiple location members in JSON output [\#158](https://github.com/cflint/CFLint/issues/158)
+- EXCESSIVE\_COMPONENT\_LENGTH reported multiple times per CFC [\#156](https://github.com/cflint/CFLint/issues/156)
+- Provide a roadmap [\#154](https://github.com/cflint/CFLint/issues/154)
+- unused-local-variable ignores variable usage inside of \<cfquery\> \(QoQ\) [\#153](https://github.com/cflint/CFLint/issues/153)
+- UNUSED\_METHOD\_ARGUMENT ignores scoped arguments [\#152](https://github.com/cflint/CFLint/issues/152)
+- Propsal: Drop "Variable x should be longer than 3 characters" warning [\#151](https://github.com/cflint/CFLint/issues/151)
+- Trying to update, can't find original git clone folder [\#150](https://github.com/cflint/CFLint/issues/150)
+- explore going to jdom 2.x [\#149](https://github.com/cflint/CFLint/issues/149)
+- AVOID\_USING\_CFSETTING\_DEBUG is not configured correctly [\#148](https://github.com/cflint/CFLint/issues/148)
+- VAR\_ALLCAPS\_NAME handles scope [\#147](https://github.com/cflint/CFLint/issues/147)
+- difference between output styles -text and -json [\#146](https://github.com/cflint/CFLint/issues/146)
+- AVOID\_USING\_CFMODULE\_TAG appears too often [\#145](https://github.com/cflint/CFLint/issues/145)
+- AVOID\_USING\_CFINCUDE\_TAG spelling [\#144](https://github.com/cflint/CFLint/issues/144)
+- Finding UNUSED\_METHOD\_ARGUMENT appears too often [\#143](https://github.com/cflint/CFLint/issues/143)
+- Parse issue [\#140](https://github.com/cflint/CFLint/issues/140)
+- Code style [\#132](https://github.com/cflint/CFLint/issues/132)
+- Group and decide which linting rules to include by default. [\#114](https://github.com/cflint/CFLint/issues/114)
+- Enhancement: Enable default config file when parsing similar to other linters [\#103](https://github.com/cflint/CFLint/issues/103)
+- Release 0.5.1-SNAPSHOT [\#97](https://github.com/cflint/CFLint/issues/97)
+- support json config instead of xml [\#95](https://github.com/cflint/CFLint/issues/95)
+
+**Merged pull requests:**
+
+- Update SureFire argLine [\#247](https://github.com/cflint/CFLint/pull/247) ([mpaluchowski](https://github.com/mpaluchowski))
+- Update the POM file [\#238](https://github.com/cflint/CFLint/pull/238) ([msp1kpj](https://github.com/msp1kpj))
+- Add a Codacy badge to README.md [\#235](https://github.com/cflint/CFLint/pull/235) ([codacy-badger](https://github.com/codacy-badger))
+- Dev [\#225](https://github.com/cflint/CFLint/pull/225) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#221](https://github.com/cflint/CFLint/pull/221) ([ryaneberly](https://github.com/ryaneberly))
+- update dev [\#218](https://github.com/cflint/CFLint/pull/218) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#217](https://github.com/cflint/CFLint/pull/217) ([ryaneberly](https://github.com/ryaneberly))
+- Dev to rulesets [\#216](https://github.com/cflint/CFLint/pull/216) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#215](https://github.com/cflint/CFLint/pull/215) ([ryaneberly](https://github.com/ryaneberly))
+- Fixtravis [\#214](https://github.com/cflint/CFLint/pull/214) ([ryaneberly](https://github.com/ryaneberly))
+- Fixed wrong parameter in error message [\#213](https://github.com/cflint/CFLint/pull/213) ([TheRealAgentK](https://github.com/TheRealAgentK))
+- Dev [\#206](https://github.com/cflint/CFLint/pull/206) ([ryaneberly](https://github.com/ryaneberly))
+- fix version [\#205](https://github.com/cflint/CFLint/pull/205) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#204](https://github.com/cflint/CFLint/pull/204) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#202](https://github.com/cflint/CFLint/pull/202) ([ryaneberly](https://github.com/ryaneberly))
+- \#194 merging configfile with filter [\#201](https://github.com/cflint/CFLint/pull/201) ([rcastagno](https://github.com/rcastagno))
+- Dev to Master [\#196](https://github.com/cflint/CFLint/pull/196) ([msp1kpj](https://github.com/msp1kpj))
+- master to dev [\#193](https://github.com/cflint/CFLint/pull/193) ([ryaneberly](https://github.com/ryaneberly))
+- Generate xml with issues using stax implementation [\#191](https://github.com/cflint/CFLint/pull/191) ([tstec](https://github.com/tstec))
+- Allow to skip analyse for specific variable names [\#190](https://github.com/cflint/CFLint/pull/190) ([tstec](https://github.com/tstec))
+- Workaround context leaking [\#189](https://github.com/cflint/CFLint/pull/189) ([tstec](https://github.com/tstec))
+- Reset checker's statistics before analyzing each file. [\#188](https://github.com/cflint/CFLint/pull/188) ([tstec](https://github.com/tstec))
+- Exclude commented arguments from counting [\#187](https://github.com/cflint/CFLint/pull/187) ([tstec](https://github.com/tstec))
+- Dev [\#184](https://github.com/cflint/CFLint/pull/184) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#181](https://github.com/cflint/CFLint/pull/181) ([ryaneberly](https://github.com/ryaneberly))
+- master to dev [\#175](https://github.com/cflint/CFLint/pull/175) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#172](https://github.com/cflint/CFLint/pull/172) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#170](https://github.com/cflint/CFLint/pull/170) ([denuno](https://github.com/denuno))
+- This pull adds some null checks and bumps the cfml.parsing dependencies [\#168](https://github.com/cflint/CFLint/pull/168) ([denuno](https://github.com/denuno))
+- Dev [\#167](https://github.com/cflint/CFLint/pull/167) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#166](https://github.com/cflint/CFLint/pull/166) ([ryaneberly](https://github.com/ryaneberly))
+- bump to use cfml.parsing 2.2.2, and abstract adding scanners [\#165](https://github.com/cflint/CFLint/pull/165) ([denuno](https://github.com/denuno))
+- String literals should not be duplicated [\#163](https://github.com/cflint/CFLint/pull/163) ([AymanDF](https://github.com/AymanDF))
+- Merging collapsible if statements increases the code's readability [\#162](https://github.com/cflint/CFLint/pull/162) ([AymanDF](https://github.com/AymanDF))
+- Using Collection.isEmpty\(\) to test for emptiness [\#161](https://github.com/cflint/CFLint/pull/161) ([AymanDF](https://github.com/AymanDF))
+- Dead stores should be removed [\#160](https://github.com/cflint/CFLint/pull/160) ([AymanDF](https://github.com/AymanDF))
+- Resources should be closed [\#159](https://github.com/cflint/CFLint/pull/159) ([AymanDF](https://github.com/AymanDF))
+- master to dev [\#157](https://github.com/cflint/CFLint/pull/157) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#155](https://github.com/cflint/CFLint/pull/155) ([ryaneberly](https://github.com/ryaneberly))
+- Fix issue where component name was always 'source' when using -stdin [\#142](https://github.com/cflint/CFLint/pull/142) ([sjmatta](https://github.com/sjmatta))
+
+## [CFLint-0.6.1](https://github.com/cflint/CFLint/tree/CFLint-0.6.1) (2015-12-19)
+[Full Changelog](https://github.com/cflint/CFLint/compare/v0.6.0...CFLint-0.6.1)
+
+**Closed issues:**
+
+- some tests fail while building CFLint [\#137](https://github.com/cflint/CFLint/issues/137)
+
+## [v0.6.0](https://github.com/cflint/CFLint/tree/v0.6.0) (2015-12-15)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint0.5.1...v0.6.0)
+
+**Implemented enhancements:**
+
+- Suggest: console progress bar [\#32](https://github.com/cflint/CFLint/issues/32)
+
+**Fixed bugs:**
+
+- HTML version of output has wrong CFLint version. [\#129](https://github.com/cflint/CFLint/issues/129)
+
+**Closed issues:**
+
+- Build failure [\#133](https://github.com/cflint/CFLint/issues/133)
+- Failure to build with maven on current master. [\#128](https://github.com/cflint/CFLint/issues/128)
+- Optionally allow plugins to recieve structure notifications [\#112](https://github.com/cflint/CFLint/issues/112)
+- Warnings for non-existing errors and non-lint errors before output. [\#105](https://github.com/cflint/CFLint/issues/105)
+- Weird messaging for missing semicolon [\#104](https://github.com/cflint/CFLint/issues/104)
+- Unable to parse function metadata with a colon in the attribute name [\#102](https://github.com/cflint/CFLint/issues/102)
+- Parse error for string concatenation in object literal [\#101](https://github.com/cflint/CFLint/issues/101)
+- parse error for "property propName;" [\#100](https://github.com/cflint/CFLint/issues/100)
+- Unable to exclude rules [\#71](https://github.com/cflint/CFLint/issues/71)
+- Problem with dynamic table and field names [\#65](https://github.com/cflint/CFLint/issues/65)
+- Unexpected warnings in cfquery tag [\#64](https://github.com/cflint/CFLint/issues/64)
+- GPG error on mvn clean install [\#23](https://github.com/cflint/CFLint/issues/23)
+
+**Merged pull requests:**
+
+- Merge pull request \#138 from cflint/master [\#139](https://github.com/cflint/CFLint/pull/139) ([ryaneberly](https://github.com/ryaneberly))
+- move changes on master to dev [\#138](https://github.com/cflint/CFLint/pull/138) ([ryaneberly](https://github.com/ryaneberly))
+- Revert "Hashmap Bug: HashMap.value\(\) does not ensure order, updated to Linked…" [\#136](https://github.com/cflint/CFLint/pull/136) ([justinmclean](https://github.com/justinmclean))
+- Hashmap Bug: HashMap.value\(\) does not ensure order, updated to Linked… [\#135](https://github.com/cflint/CFLint/pull/135) ([playedinane](https://github.com/playedinane))
+- Fix version number in XML and HTML outputs [\#131](https://github.com/cflint/CFLint/pull/131) ([justinmclean](https://github.com/justinmclean))
+- Rule to check for unused arguments in methods [\#127](https://github.com/cflint/CFLint/pull/127) ([justinmclean](https://github.com/justinmclean))
+- Rule to check for unused local variables [\#126](https://github.com/cflint/CFLint/pull/126) ([justinmclean](https://github.com/justinmclean))
+- Introduce file driven tests. [\#125](https://github.com/cflint/CFLint/pull/125) ([ryaneberly](https://github.com/ryaneberly))
+- Dev release prep [\#124](https://github.com/cflint/CFLint/pull/124) ([ryaneberly](https://github.com/ryaneberly))
+- Rule to check method argument names [\#123](https://github.com/cflint/CFLint/pull/123) ([justinmclean](https://github.com/justinmclean))
+- Fix issue were rule was being passed file path not file name [\#122](https://github.com/cflint/CFLint/pull/122) ([justinmclean](https://github.com/justinmclean))
+- Rule to check if .cfm file starts with an upper case letter [\#121](https://github.com/cflint/CFLint/pull/121) ([justinmclean](https://github.com/justinmclean))
+- Rule to check component naming [\#120](https://github.com/cflint/CFLint/pull/120) ([justinmclean](https://github.com/justinmclean))
+- Rule to checking for old way of creating components via createObject [\#118](https://github.com/cflint/CFLint/pull/118) ([justinmclean](https://github.com/justinmclean))
+- Pluginnotify [\#117](https://github.com/cflint/CFLint/pull/117) ([ryaneberly](https://github.com/ryaneberly))
+- check for cfinclude inside cfcs [\#116](https://github.com/cflint/CFLint/pull/116) ([justinmclean](https://github.com/justinmclean))
+- Dev [\#115](https://github.com/cflint/CFLint/pull/115) ([ryaneberly](https://github.com/ryaneberly))
+- Add -stdin and -stdout parameters [\#113](https://github.com/cflint/CFLint/pull/113) ([sjmatta](https://github.com/sjmatta))
+- \#95.  jsonconfig [\#111](https://github.com/cflint/CFLint/pull/111) ([ryaneberly](https://github.com/ryaneberly))
+- Betterparsingerr [\#110](https://github.com/cflint/CFLint/pull/110) ([ryaneberly](https://github.com/ryaneberly))
+- Provide some rules around naming of variables and methods [\#109](https://github.com/cflint/CFLint/pull/109) ([justinmclean](https://github.com/justinmclean))
+- Update code and add tests to check in return statements [\#108](https://github.com/cflint/CFLint/pull/108) ([justinmclean](https://github.com/justinmclean))
+- Dev [\#99](https://github.com/cflint/CFLint/pull/99) ([ryaneberly](https://github.com/ryaneberly))
+- Dev [\#98](https://github.com/cflint/CFLint/pull/98) ([ryaneberly](https://github.com/ryaneberly))
+- Added rule to check for repeated hard coded values [\#94](https://github.com/cflint/CFLint/pull/94) ([justinmclean](https://github.com/justinmclean))
+- Rule to check for complex boolean expressions [\#93](https://github.com/cflint/CFLint/pull/93) ([justinmclean](https://github.com/justinmclean))
+- Check for explicit boolean expression checking for true and false [\#92](https://github.com/cflint/CFLint/pull/92) ([justinmclean](https://github.com/justinmclean))
+- Rule to check for structNew and suggest using {} instead [\#91](https://github.com/cflint/CFLint/pull/91) ([justinmclean](https://github.com/justinmclean))
+- Rule to check for ArrayNew and suggest using \[\] instead [\#90](https://github.com/cflint/CFLint/pull/90) ([justinmclean](https://github.com/justinmclean))
+
+## [CFLint0.5.1](https://github.com/cflint/CFLint/tree/CFLint0.5.1) (2015-10-12)
+[Full Changelog](https://github.com/cflint/CFLint/compare/v0.5...CFLint0.5.1)
+
+**Implemented enhancements:**
+
+- Function Length Checker In Config vs. Code [\#68](https://github.com/cflint/CFLint/issues/68)
+- JSON output [\#62](https://github.com/cflint/CFLint/issues/62)
+
+**Closed issues:**
+
+- context.addMessage vs bugs.add [\#72](https://github.com/cflint/CFLint/issues/72)
+- Error when reading config file [\#69](https://github.com/cflint/CFLint/issues/69)
+- cflint-disable / cflint-enable ? [\#66](https://github.com/cflint/CFLint/issues/66)
+- Release v0.5.0 [\#63](https://github.com/cflint/CFLint/issues/63)
+- Returning incorrect version number [\#46](https://github.com/cflint/CFLint/issues/46)
+
+**Merged pull requests:**
+
+- Rule to check for writeDump in cfset tags and script blocks [\#89](https://github.com/cflint/CFLint/pull/89) ([justinmclean](https://github.com/justinmclean))
+- Rule to work out simple complexity measure for functions [\#88](https://github.com/cflint/CFLint/pull/88) ([justinmclean](https://github.com/justinmclean))
+- Warn about abort statements in script blocks [\#87](https://github.com/cflint/CFLint/pull/87) ([justinmclean](https://github.com/justinmclean))
+- Rule to check for incorrect name attribute on component [\#82](https://github.com/cflint/CFLint/pull/82) ([justinmclean](https://github.com/justinmclean))
+- Component has too many functions [\#79](https://github.com/cflint/CFLint/pull/79) ([justinmclean](https://github.com/justinmclean))
+- Function has too many arguments [\#78](https://github.com/cflint/CFLint/pull/78) ([justinmclean](https://github.com/justinmclean))
+- Cfabort [\#76](https://github.com/cflint/CFLint/pull/76) ([justinmclean](https://github.com/justinmclean))
+- Added counts of each error type. [\#75](https://github.com/cflint/CFLint/pull/75) ([justinmclean](https://github.com/justinmclean))
+- Rule to check function return type exists or is any [\#74](https://github.com/cflint/CFLint/pull/74) ([justinmclean](https://github.com/justinmclean))
+- Function argument checker [\#73](https://github.com/cflint/CFLint/pull/73) ([justinmclean](https://github.com/justinmclean))
+- Added simple hint checker [\#70](https://github.com/cflint/CFLint/pull/70) ([justinmclean](https://github.com/justinmclean))
+
+## [v0.5](https://github.com/cflint/CFLint/tree/v0.5) (2015-06-16)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.4-release...v0.5)
+
+**Closed issues:**
+
+- Having trouble using filterFile [\#60](https://github.com/cflint/CFLint/issues/60)
+- Issue with pom.xml file [\#59](https://github.com/cflint/CFLint/issues/59)
+- change license to BSD [\#58](https://github.com/cflint/CFLint/issues/58)
+- Build failure [\#56](https://github.com/cflint/CFLint/issues/56)
+- Support for CF 11 [\#55](https://github.com/cflint/CFLint/issues/55)
+- Misc. Parsing Error? [\#54](https://github.com/cflint/CFLint/issues/54)
+- maven install should install the binaries in a usable way [\#51](https://github.com/cflint/CFLint/issues/51)
+- Argument appScope is not required and does not define a default value. [\#50](https://github.com/cflint/CFLint/issues/50)
+- Unable to Parse QueryExecute Functions [\#49](https://github.com/cflint/CFLint/issues/49)
+- Vim syntastic support [\#48](https://github.com/cflint/CFLint/issues/48)
+- Speeding up CFLint [\#47](https://github.com/cflint/CFLint/issues/47)
+- Lint of cfprocresult fails in function when array is used. [\#45](https://github.com/cflint/CFLint/issues/45)
+- Arch Linux AUR [\#44](https://github.com/cflint/CFLint/issues/44)
+- "import" statement breaks parsing for scripted components [\#43](https://github.com/cflint/CFLint/issues/43)
+- maven build instructions should address common distribution requirements [\#42](https://github.com/cflint/CFLint/issues/42)
+- License [\#41](https://github.com/cflint/CFLint/issues/41)
+- Errors while parsing double assignments [\#40](https://github.com/cflint/CFLint/issues/40)
+- Errors while parsing variables named "string" [\#39](https://github.com/cflint/CFLint/issues/39)
+- CFLint-ui asking for 4G of Memory [\#38](https://github.com/cflint/CFLint/issues/38)
+- Use latest \(antlr4\) version of cfparser. [\#37](https://github.com/cflint/CFLint/issues/37)
+- Add Ability to Preview CFParser Snapshots from Sonatype. [\#36](https://github.com/cflint/CFLint/issues/36)
+- CFLint Should Download Latest Version of CFParser [\#35](https://github.com/cflint/CFLint/issues/35)
+- Failed to execute goal on project CFLint: Could not resolve dependencies [\#34](https://github.com/cflint/CFLint/issues/34)
+- no cflint version could be extracted with SublimeLinter [\#33](https://github.com/cflint/CFLint/issues/33)
+- parse error "can't look backwards more than one token in this stream" [\#24](https://github.com/cflint/CFLint/issues/24)
+- NoViableAltException java.lang.NullPointerException [\#22](https://github.com/cflint/CFLint/issues/22)
+- Mac OSX 10.9.4 Good build can not find  [\#20](https://github.com/cflint/CFLint/issues/20)
+- Multiple exceptions in output [\#11](https://github.com/cflint/CFLint/issues/11)
+
+**Merged pull requests:**
+
+- Update README.md [\#57](https://github.com/cflint/CFLint/pull/57) ([AntoineGagnon](https://github.com/AntoineGagnon))
+- note "mvn install -D assembleDirectory=" option [\#53](https://github.com/cflint/CFLint/pull/53) ([displague](https://github.com/displague))
+- link to cflint-syntastic in the README [\#52](https://github.com/cflint/CFLint/pull/52) ([displague](https://github.com/displague))
+
+## [CFLint-0.4-release](https://github.com/cflint/CFLint/tree/CFLint-0.4-release) (2015-02-10)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.3.1...CFLint-0.4-release)
+
+## [CFLint-0.3.1](https://github.com/cflint/CFLint/tree/CFLint-0.3.1) (2015-02-06)
+[Full Changelog](https://github.com/cflint/CFLint/compare/0.4...CFLint-0.3.1)
+
+## [0.4](https://github.com/cflint/CFLint/tree/0.4) (2015-02-06)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.3...0.4)
+
+## [CFLint-0.3](https://github.com/cflint/CFLint/tree/CFLint-0.3) (2015-02-06)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.4...CFLint-0.3)
+
+## [CFLint-0.4](https://github.com/cflint/CFLint/tree/CFLint-0.4) (2015-02-06)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.3.0...CFLint-0.4)
+
+## [CFLint-0.3.0](https://github.com/cflint/CFLint/tree/CFLint-0.3.0) (2015-02-05)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.2.0...CFLint-0.3.0)
+
+**Implemented enhancements:**
+
+- Excess Libraries [\#16](https://github.com/cflint/CFLint/issues/16)
+
+**Fixed bugs:**
+
+- CFParser Dependencies Not Resolved [\#18](https://github.com/cflint/CFLint/issues/18)
+
+**Closed issues:**
+
+- Trying out the configfile from the command line and getting errors [\#31](https://github.com/cflint/CFLint/issues/31)
+- NESTED\_CFOUTPUT false positive [\#30](https://github.com/cflint/CFLint/issues/30)
+- Exclude WEB-INF folder [\#29](https://github.com/cflint/CFLint/issues/29)
+- cflint --version returns error [\#28](https://github.com/cflint/CFLint/issues/28)
+- Maven build fails with error. [\#27](https://github.com/cflint/CFLint/issues/27)
+-  QUERYPARAM\_REQ message should reflect the cf tag version not the cf script version. [\#26](https://github.com/cflint/CFLint/issues/26)
+- Default cflintexclude.json should only ignore MISSING\_VAR's in init\(\) functions, other violations should NOT be ignored [\#25](https://github.com/cflint/CFLint/issues/25)
+- \<cfset/\> on multiple lines does not process [\#21](https://github.com/cflint/CFLint/issues/21)
+- Convert bugs.add\(\) to a plugin format. [\#19](https://github.com/cflint/CFLint/issues/19)
+- Lint Error Question [\#17](https://github.com/cflint/CFLint/issues/17)
+- Add the antlr grammar code generation to the maven build. [\#15](https://github.com/cflint/CFLint/issues/15)
+
+## [CFLint-0.2.0](https://github.com/cflint/CFLint/tree/CFLint-0.2.0) (2014-08-12)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.1.7...CFLint-0.2.0)
+
+**Closed issues:**
+
+- Machine independent new lines [\#13](https://github.com/cflint/CFLint/issues/13)
+- Docs for using linter via java [\#12](https://github.com/cflint/CFLint/issues/12)
+- Typo in read me \(and logo\) [\#10](https://github.com/cflint/CFLint/issues/10)
+- compat issue with Local History package [\#9](https://github.com/cflint/CFLint/issues/9)
+- does not support tagless components [\#8](https://github.com/cflint/CFLint/issues/8)
+- Add severity level to each issue in stdout [\#7](https://github.com/cflint/CFLint/issues/7)
+- Add -version flag [\#6](https://github.com/cflint/CFLint/issues/6)
+- It would be useful to have a -q \(--quiet\) option [\#4](https://github.com/cflint/CFLint/issues/4)
+- It should be possible to specifiy just one file to be scanned. [\#3](https://github.com/cflint/CFLint/issues/3)
+- Specifying -textfile as an argument, implies -text should be set. [\#2](https://github.com/cflint/CFLint/issues/2)
+
+## [CFLint-0.1.7](https://github.com/cflint/CFLint/tree/CFLint-0.1.7) (2014-04-03)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.1.8...CFLint-0.1.7)
+
+## [CFLint-0.1.8](https://github.com/cflint/CFLint/tree/CFLint-0.1.8) (2014-04-03)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.1.6...CFLint-0.1.8)
+
+**Closed issues:**
+
+- ignore .cfm~ files [\#1](https://github.com/cflint/CFLint/issues/1)
+
+## [CFLint-0.1.6](https://github.com/cflint/CFLint/tree/CFLint-0.1.6) (2014-04-01)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.1.5...CFLint-0.1.6)
+
+## [CFLint-0.1.5](https://github.com/cflint/CFLint/tree/CFLint-0.1.5) (2014-02-08)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.1.4...CFLint-0.1.5)
+
+## [CFLint-0.1.4](https://github.com/cflint/CFLint/tree/CFLint-0.1.4) (2013-12-27)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.1.3...CFLint-0.1.4)
+
+## [CFLint-0.1.3](https://github.com/cflint/CFLint/tree/CFLint-0.1.3) (2013-12-19)
+[Full Changelog](https://github.com/cflint/CFLint/compare/CFLint-0.1.2...CFLint-0.1.3)
+
+## [CFLint-0.1.2](https://github.com/cflint/CFLint/tree/CFLint-0.1.2) (2013-12-06)
+[Full Changelog](https://github.com/cflint/CFLint/compare/0.1.0...CFLint-0.1.2)
+
+## [0.1.0](https://github.com/cflint/CFLint/tree/0.1.0) (2013-11-23)
+
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*
+
+\* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,33 @@ plugins {
     id 'eclipse'
 }
 
+// Helper functions and constants
+def getLatestTag = { ->
+    try {
+        def stdout = new ByteArrayOutputStream()
+
+        String osName = System.getProperty('os.name').toLowerCase();
+
+        if (osName.contains('win')) {
+            //exec {
+            //    commandLine 'cmd', '/c', 'hg.exe', 'parent', '--template', '{rev}'
+            //    standardOutput = stdout
+            //}
+        } else if (osName.contains('mac')) {
+            exec {
+                commandLine "src/main/resources/scripts/getLatestTag.sh"
+                standardOutput = stdout
+            }
+        }
+        return stdout.toString()
+    }
+    catch (ignored) {
+        print("fail")
+        println(ignored.toString())
+        throw new GradleException('Git command to find latest tag failed')
+    }
+}
+
 apply plugin: "base"
 apply plugin: "signing"
 apply plugin: "com.bmuschko.nexus"
@@ -80,6 +107,7 @@ jar {
 }
 
 task fatJar(type: Jar) {
+
     manifest.from jar.manifest
     classifier = 'all'
     from {
@@ -96,7 +124,19 @@ artifacts {
     archives fatJar
 }
 
-task gitChangelogTask(type: se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask) {
+task gitChangelog(type: se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask) {
+    group "documentation"
+
     file = new File("CHANGELOG.md");
     templateContent = file('src/main/resources/changelog.mustache').getText('UTF-8');
+}
+
+task githubChangelogGenerator {
+    group "documentation"
+
+    doLast {
+        def latestTag = getLatestTag()
+        def p = ['src/main/resources/scripts/writeChangelog.sh', latestTag].execute()
+        println p.text
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
     repositories {
         mavenLocal()
@@ -12,17 +11,17 @@ buildscript {
             url "https://plugins.gradle.org/m2/"
         }
     }
-     dependencies {
-         classpath 'com.bmuschko:gradle-nexus-plugin:2.3'
-         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
-      classpath "gradle.plugin.se.bjurr.gitchangelog:git-changelog-gradle-plugin:1.50"
-   }
- }
+    dependencies {
+        classpath 'com.bmuschko:gradle-nexus-plugin:2.3'
+        classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
+        classpath "gradle.plugin.se.bjurr.gitchangelog:git-changelog-gradle-plugin:1.50"
+    }
+}
 
 plugins {
-  id 'java'
-  id 'com.github.johnrengelman.shadow' version '1.2.4'
-  id 'eclipse'
+    id 'java'
+    id 'com.github.johnrengelman.shadow' version '1.2.4'
+    id 'eclipse'
 }
 
 apply plugin: "base"
@@ -35,7 +34,6 @@ apply from: 'cobertura.gradle'
 apply from: 'deploy.gradle'
 apply plugin: "se.bjurr.gitchangelog.git-changelog-gradle-plugin"
 
-
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
@@ -46,21 +44,21 @@ repositories {
     maven { url "http://cfmlprojects.org/artifacts" }
 }
 dependencies {
-    compile group: 'com.github.cfparser', name: 'cfml.parsing', version:'2.6.0'
-    compile group: 'commons-cli', name: 'commons-cli', version:'1.2'
-    compile group: 'ro.fortsoft.pf4j', name: 'pf4j', version:'0.6'
-    compile group: 'ant', name: 'ant', version:'1.7.0'
-    compile group: 'com.sun.xml.bind', name: 'jaxb-impl', version:'2.1.8'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version:'2.8.6'
-    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version:'2.8.6'
-    compile (group: 'net.java.dev.stax-utils', name: 'stax-utils', version: '20070216'){
+    compile group: 'com.github.cfparser', name: 'cfml.parsing', version: '2.6.0'
+    compile group: 'commons-cli', name: 'commons-cli', version: '1.2'
+    compile group: 'ro.fortsoft.pf4j', name: 'pf4j', version: '0.6'
+    compile group: 'ant', name: 'ant', version: '1.7.0'
+    compile group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.1.8'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.8.6'
+    compile group: 'com.fasterxml.jackson.module', name: 'jackson-module-jaxb-annotations', version: '2.8.6'
+    compile(group: 'net.java.dev.stax-utils', name: 'stax-utils', version: '20070216') {
         exclude module: 'jsr173-ri'
         exclude module: 'jsr173'
     }
     // https://mvnrepository.com/artifact/commons-io/commons-io
     compile group: 'commons-io', name: 'commons-io', version: '2.5'
 
-    testCompile group: 'junit', name: 'junit', version:'4.12'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
 test {
@@ -73,25 +71,25 @@ test {
 }
 
 jar {
-  manifest {
-    attributes(
-      'Main-Class': 'com.cflint.cli.CFLintCLI',
-      'Implementation-Version': version,
-    )
-  }
+    manifest {
+        attributes(
+            'Main-Class': 'com.cflint.cli.CFLintCLI',
+            'Implementation-Version': version,
+        )
+    }
 }
 
 task fatJar(type: Jar) {
-  manifest.from jar.manifest
-  classifier = 'all'
-  from {
-    configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }
-  } {
+    manifest.from jar.manifest
+    classifier = 'all'
+    from {
+        configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) }
+    } {
         exclude "META-INF/*.SF"
         exclude "META-INF/*.DSA"
         exclude "META-INF/*.RSA"
-  }
-  with jar
+    }
+    with jar
 }
 
 artifacts {

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,17 @@
 
 buildscript {
-     repositories {
-         mavenLocal()
-         jcenter {
+    repositories {
+        mavenLocal()
+        jcenter {
             url "http://jcenter.bintray.com/"
         }
-        maven { url "http://oss.sonatype.org/content/repositories/snapshots/" 
+        maven {
+            url "http://oss.sonatype.org/content/repositories/snapshots/"
+        }
+        maven {
             url "https://plugins.gradle.org/m2/"
         }
-     }
+    }
      dependencies {
          classpath 'com.bmuschko:gradle-nexus-plugin:2.3'
          classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3"
@@ -94,6 +97,7 @@ task fatJar(type: Jar) {
 artifacts {
     archives fatJar
 }
+
 task gitChangelogTask(type: se.bjurr.gitchangelog.plugin.gradle.GitChangelogTask) {
     file = new File("CHANGELOG.md");
     templateContent = file('src/main/resources/changelog.mustache').getText('UTF-8');

--- a/src/main/resources/scripts/getLatestTag.sh
+++ b/src/main/resources/scripts/getLatestTag.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+git tag -l --format="%(creatordate:iso8601)|%(refname:short)" | sort -r | head -n 1 | awk -F'|' '{print $2}'

--- a/src/main/resources/scripts/writeChangelog.sh
+++ b/src/main/resources/scripts/writeChangelog.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/Users/kai/.rbenv/shims/github_changelog_generator -u cflint -p CFLint --token <github token> --output CHANGELOG.md --base CHANGELOG.md --no-unreleased --since-tag $1 --header-label


### PR DESCRIPTION
This is the integration of an additional solution for creating the changelog.

In general it requires the installation of https://github.com/skywinder/github-changelog-generator as a ruby gem on ones local machine.

The generator ends up as a binary on your system that can be called via a shell. There's not gradle task for it. The code in this pull request provides a task documentation/githubChangelogGenerator that relies on two bash scripts that have been added to the repo.

The first one, getLatestTag.sh retrieves the most current tag from the repo. This then gets passed in as the "since"-parameter into writeChangelog.sh (which itself then calls githubChangelogGenerator).

All this currently relies on being on a Mac OS X system (or Linux with marginal changes) and some of the paths are hardcoded. I can run it fine, see the newly generated CHANGELOG.md in this branch. You can see that it has "custom" content for 1.2.0 and 1.2.2 and is currently showing all the content for all tags (... 1.2.2, 1.3.0-RC1, 1.3.0-RC2)

The idea is that from NOW onwards, whenever a new tag is added to the repo, the Gradle task is being executed. For the next tag, let's say "CFLint-1.3.0" , said tag will then be passed as "since" into the changelog tool, run the changelog with that parameter and prepend that to the existing file (leaving all the custom content untouched). Then one could write a few lines that sum up the big items/themes of a release, add to the CHANGELOG file manually, save and commit/push.

NOTE: The current changelog generator (gitChangelog) is still there, also moved to the documentation group in Gradle and renamed from gitChangelogTask to gitChangelog.

Caveeats:

- Dependency on OSX and a hardcoded path in my setup (that I can get rid of with a bit of additional work) - but someone would need to look into the Windows side of things - not just running windows scripts from Gradle, but also how to "translate" this chain of unix pipes into Windows:

`git tag -l --format="%(creatordate:iso8601)|%(refname:short)" | sort -r | head -n 1 | awk -F'|' '{print $2}'`

- Requires a Github token in writeChangelog.sh - that (and maybe the path) would need to move into a local and git-ignored settings file people have to manage and not commit for obvious reasons.
