### PR TITLE
#554 Add queryExecute to QueryParamChecker

### DIFF
--- a/src/main/java/com/cflint/plugins/core/QueryParamChecker.java
+++ b/src/main/java/com/cflint/plugins/core/QueryParamChecker.java
@@ -20,7 +20,7 @@ public class QueryParamChecker extends CFLintScannerAdapter {
     public void expression(final CFExpression expression, final Context context, final BugList bugs) {
         if (expression instanceof CFFunctionExpression) {
             final CFFunctionExpression functionExpression = (CFFunctionExpression) expression;
-            if ("setSql".equalsIgnoreCase(functionExpression.getFunctionName())
+            if ("setSql".equalsIgnoreCase(functionExpression.getFunctionName()) || "queryExecute".equalsIgnoreCase(functionExpression.getFunctionName())
                 && !functionExpression.getArgs().isEmpty()) {
                 final CFExpression argsExpression = functionExpression.getArgs().get(0);
                 final Pattern p = Pattern.compile(".*#[^#].*", Pattern.DOTALL);

--- a/src/main/resources/cflint.definition.json
+++ b/src/main/resources/cflint.definition.json
@@ -76,7 +76,7 @@
             "message": [
                 {
                     "code": "QUERYPARAM_REQ",
-                    "messageText": "setSql() statement should use .addParam() instead of #'s name=\"${variable}\"",
+                    "messageText": "Use query parameters for variables in sql statements.",
                     "severity": "WARNING"
                 },
                 {

--- a/src/main/resources/cflint.description.txt
+++ b/src/main/resources/cflint.description.txt
@@ -5,7 +5,7 @@ NO_DEFAULT_INSIDE_SWITCH:Missing default switch statement.
 GLOBAL_VAR:Global variable exists.
 NESTED_CFOUTPUT:Nexted cfoutput with cfquery tag.
 OUTPUT_ATTR:Tag should have output='false'.
-QUERYPARAM_REQ:SetSql() statement should use .addParam().
+QUERYPARAM_REQ:Use query parameters for variables in sql statements.
 CFQUERYPARAM_REQ:cfquery should use <cfqueryparam>.
 QUERYNEW_DATATYPE:QueryNew statement should specify datatypes.
 MISSING_VAR:Variable is not declared with a var statement.

--- a/src/test/java/com/cflint/TestCFBugs_QueryParams.java
+++ b/src/test/java/com/cflint/TestCFBugs_QueryParams.java
@@ -160,4 +160,32 @@ public class TestCFBugs_QueryParams {
         assertEquals(575, result.get(0).getOffset());
     }
 
+    @Test
+    public void testCFScript_QueryParams_queryExecute_OK() throws CFLintScanException {
+        final String cfcSrc = "component {\r\n" 
+            + "public void function getData() {\r\n"
+            + "queryExecute(\"\r\n"
+            + "   SELECT id from table where id = :id\r\n"
+            + "\",{\r\n"
+            + "   id = {cfsqltype=\"CF_SQL_INTEGER\", value=arguments.id, maxlength=10}\r\n"
+            + "});\r\n}\r\n}";
+        CFLintResult lintresult = cfBugs.scan(cfcSrc, "test");
+        final Map<String, List<BugInfo>> result = lintresult.getIssues();
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    public void testCFScript_QueryParams_queryExecute_Hashes() throws CFLintScanException {
+        final String cfcSrc = "component {\r\n" 
+            + "public void function getData() {\r\n"
+            + "queryExecute(\"\r\n"
+            + "   SELECT id from table where id = #arguments.id#\r\n"
+            + "\");\r\n}\r\n}";
+        CFLintResult lintresult = cfBugs.scan(cfcSrc, "test");
+        final List<BugInfo> result = lintresult.getIssues().get("QUERYPARAM_REQ");
+        assertEquals(1, result.size());
+        assertEquals("QUERYPARAM_REQ", result.get(0).getMessageCode());
+        assertEquals(3, result.get(0).getLine());
+    }
+
 }


### PR DESCRIPTION
Added the `queryExecute` method to the QueryParamChecker and changed the message for code QUERYPARAM_REQ. #554 