### PR TITLE
Update file change

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The exception is debug mode. In debug mode, CFLint will always ignore user setti
 
 The flag `-html` instructs CFLint to create an HTML document. The full syntax is:
 
-    -html -html <outputFileName>
+    -html -htmlfile <outputFileName>
 
 ### XML
 


### PR DESCRIPTION
The syntax for creating an HTML-file in README.MD is incorrect
`-html -html <outputfile>`
should be
`-html -htmlfile <outputfile>`
according to the integrated help function