### PR TITLE
Changing to secure URL for Maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ targetCompatibility = 1.8
 
 repositories {
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
-    maven { url "http://repo.maven.apache.org/maven2" }
+    maven { url "https://repo.maven.apache.org/maven2" }
     maven { url "https://oss.sonatype.org/content/repositories/releases" }
     maven { url "http://cfmlprojects.org/artifacts" }
 }


### PR DESCRIPTION
http://repo.maven.apache.org/maven needs to be https://repo.maven.apache.org/maven otherwise GRADLE will fail