### PR TITLE
Plugin for IntelliJ IDEA Ultimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,5 +567,6 @@ Please note that the majority of the libraries and projects mentioned here are n
 * [SonarQube plugin](https://github.com/stepstone-tech/sonar-coldfusion)
 * [NPM wrapper](https://github.com/morgdenn/npm-cflint)
 * Vim [Syntastic support for CFLint](https://github.com/cflint/cflint-syntastic)
+* [IntelliJ IDEA Ultimate plugin](https://github.com/Pr1st0n/cflint-intellij)
 
 If you have been working on (or are thinking about starting) a project related to CFLint, please let us know. We're happy to include relevant third-party projects to the list above.


### PR DESCRIPTION
Hi there,

It seems that [IntelliJ plugin](https://github.com/cflint/CFLint/blame/master/README.md#L565) is not maintained any more, so I've implemented a CFLint plugin for IntelliJ IDEA Ultimate (the only JetBrains IDE that has CFML support).
I used CFLint API to perform code analysis as mentioned in #474
It's an early release, but could already be useful for Coldfusion developers working with IntelliJ IDEA.
The plugin is available in [JetBrains Marketplace](https://plugins.jetbrains.com/plugin/15567-cflint) and could be installed directly from IntelliJ IDEA plugins menu.